### PR TITLE
Update all octref/vetur GitHub URLs to vuejs/vetur

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Then `F5` with `all` target to start debugging.
 
 > Tip: In VSCode, use F1 -> Inspect TM Scopes:
 
-![scope](https://github.com/octref/vetur/blob/master/asset/scope.png)
+![scope](https://github.com/vuejs/vetur/blob/master/asset/scope.png)
 
 ## Doc
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 - [ ] I searched through existing issues.
-- [ ] I have looked through docs at https://octref.github.io/vetur/
+- [ ] I have looked through docs at https://vuejs.github.io/vetur/
 
 ## Info
 
@@ -25,5 +25,5 @@
 
   1. Try disabling / removing other Vue extensions for VSCode.
 
-  2. For crash / memory usage problem, try adding a tsconfig/jsconfig that only includes your client side Vue code, see more at: https://octref.github.io/vetur/setup.html#overall
+  2. For crash / memory usage problem, try adding a tsconfig/jsconfig that only includes your client side Vue code, see more at: https://vuejs.github.io/vetur/setup.html#overall
 -->

--- a/build/update-docs.sh
+++ b/build/update-docs.sh
@@ -6,4 +6,4 @@ cd _book
 git init
 git add -A
 git commit -m 'update book'
-git push -f git@github.com:octref/vetur.git master:gh-pages
+git push -f git@github.com:vuejs/vetur.git master:gh-pages

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Vue tooling for VSCode.
 🎉 [VueConf 2017 Talk Slide](https://www.dropbox.com/sh/eb4w8k3orh0j391/AAB3HaJexbGLa2tCP14BI8oJa?dl=0) 🎉
 
 This extension is under heavy development.
-You can [open an issue](https://github.com/octref/vetur/issues/new) for bugs or feature requests.
+You can [open an issue](https://github.com/vuejs/vetur/issues/new) for bugs or feature requests.
 
 ## Features
 
@@ -26,7 +26,7 @@ You can [open an issue](https://github.com/octref/vetur/issues/new) for bugs or 
 
 ## Contributing
 
-[Contribution Guide](https://github.com/octref/vetur/blob/master/.github/CONTRIBUTING.md).
+[Contribution Guide](https://github.com/vuejs/vetur/blob/master/.github/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/book.json
+++ b/docs/book.json
@@ -3,11 +3,11 @@
   "plugins": ["-sharing", "edit-link", "theme-vuejs@git+https://github.com/pearofducks/gitbook-plugin-theme-vuejs.git", "-fontsettings", "github"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/octref/vetur/edit/master/docs",
+      "base": "https://github.com/vuejs/vetur/edit/master/docs",
       "label": "Edit This Page"
     },
     "github": {
-      "url": "https://github.com/octref/vetur"
+      "url": "https://github.com/vuejs/vetur"
     }
   },
   "links": {

--- a/docs/emmet.md
+++ b/docs/emmet.md
@@ -15,4 +15,4 @@ In your user settings, set
 
 #### [To Write]
 
-https://github.com/octref/vetur/issues/232
+https://github.com/vuejs/vetur/issues/232

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,3 @@
 # Roadmap
 
-See https://github.com/octref/vetur/issues/188 for now.
+See https://github.com/vuejs/vetur/issues/188 for now.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/octref/vetur.git"
+    "url": "https://github.com/vuejs/vetur.git"
   },
   "keywords": [
     "vetur",

--- a/server/README.md
+++ b/server/README.md
@@ -1,7 +1,7 @@
 VueJS Language Server
 -----
 
-Extracted from [vetur](https://github.com/octref/vetur).
+Extracted from [vetur](https://github.com/vuejs/vetur).
 
 This can be used for different editors.
 


### PR DESCRIPTION
Replace github.com/octref/vetur with github.com/vuejs/vetur

Replace octref.github.io/vetur with vuejs.github.io/vetur