### PR TITLE
Add Onsen UI support

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,8 @@
     "typescript": "^2.3.4",
     "vscode-css-languageservice": "^2.0.0",
     "vscode-languageserver": "^3.3.0",
-    "vscode-uri": "^1.0.1"
+    "vscode-uri": "^1.0.1",
+    "vue-onsenui-helper-json": "^1.0.0"
   },
   "devDependencies": {
     "@types/js-beautify": "0.0.30",

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -3,6 +3,7 @@ import { getHTML5TagProvider } from './htmlTags';
 import { getVueTagProvider } from './vueTags';
 import { getRouterTagProvider } from './routerTags';
 import { getElementTagProvider } from './elementTags';
+import { getOnsenTagProvider } from './onsenTags';
 
 import * as ts from 'typescript';
 import * as fs from 'fs';
@@ -11,7 +12,8 @@ export let allTagProviders : IHTMLTagProvider[] = [
   getHTML5TagProvider(),
   getVueTagProvider(),
   getRouterTagProvider(),
-  getElementTagProvider()
+  getElementTagProvider(),
+  getOnsenTagProvider()
 ];
 
 export function getDefaultSetting(workspacePath: string) {
@@ -19,7 +21,8 @@ export function getDefaultSetting(workspacePath: string) {
     html5: true,
     vue: true,
     router: false,
-    element: false
+    element: false,
+    onsen: false
   };
   try {
     let packagePath = ts.findConfigFile(workspacePath, ts.sys.fileExists, 'package.json');
@@ -29,6 +32,9 @@ export function getDefaultSetting(workspacePath: string) {
     }
     if (packageJson.dependencies['element-ui']) {
       setting['element'] = true;
+    }
+    if (packageJson.dependencies['vue-onsenui']) {
+      setting['onsen'] = true;
     }
   } catch (e) { }
   return setting;

--- a/server/src/modes/template/tagProviders/onsenTags.ts
+++ b/server/src/modes/template/tagProviders/onsenTags.ts
@@ -1,0 +1,49 @@
+import { IHTMLTagProvider, Priority } from './common';
+import * as tags from 'vue-onsenui-helper-json/vue-onsenui-tags.json';
+import * as attributes from 'vue-onsenui-helper-json/vue-onsenui-attributes.json';
+
+export function getOnsenTagProvider(): IHTMLTagProvider {
+  return {
+    getId: () => 'onsen',
+    priority: Priority.Library,
+    isApplicable: languageId => languageId === 'vue-html',
+    collectTags(collector) {
+      for (const tagName in tags) {
+        collector(tagName, tags[tagName].description || '');
+      }
+    },
+    collectAttributes(tag, collector) {
+      if (!tags[tag]) {
+        return;
+      }
+      const attrs = tags[tag].attributes;
+      if (!attrs) {
+        return;
+      }
+      for (let attr of attrs) {
+        const detail = findAttributeDetail(tag, attr);
+        collector(attr, undefined, detail && detail.description || '');
+      }
+    },
+    collectValues(tag, attr, collector) {
+      if (!tags[tag]) {
+        return;
+      }
+      const attrs = tags[tag].attributes;
+      if (!attrs || attrs.indexOf(attr) < 0) {
+        return;
+      }
+      const detail = findAttributeDetail(tag, attr);
+      if (!detail || !detail.options) {
+        return;
+      }
+      for (const option of detail.options) {
+        collector(option);
+      }
+    }
+  };
+}
+
+function findAttributeDetail(tag: string, attr: string) {
+  return attributes[attr] || attributes[tag + '/' + attr];
+}

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1025,6 +1025,10 @@ vue-eslint-parser@^1.1.0-7:
     lodash.sortedindexby "^4.6.0"
     parse5 "^3.0.0"
 
+vue-onsenui-helper-json@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vue-onsenui-helper-json/-/vue-onsenui-helper-json-1.0.0.tgz#9b70ce18fd0d0138a0b9b68b914340036deabae7"
+
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"


### PR DESCRIPTION
@octref @HerringtonDarkholme (Cc: @masahirotanaka)
Hi, I'm a developer of [Onsen UI](https://github.com/OnsenUI/OnsenUI), a UI library for mobile development (simliar to Mint UI).
I heard that our chief (@masahirotanaka) talked with you (@octref) in VueConf 2017.

This PR adds support for Onsen UI based on [`OnsenUI/vue-onsenui-helper-json`](https://github.com/OnsenUI/vue-onsenui-helper-json) (already published to NPM registry).
I chose the same structure as [`ElementUI/element-helper-json`](https://github.com/ElementUI/element-helper-json) to avoid complexity.

The completion works as follows:

![2017-07-02 20 44 54](https://user-images.githubusercontent.com/19771915/27769663-10f881d6-5f6a-11e7-9854-e99d6605f050.png)

Could you please review this PR?