### PR TITLE
lang="html" should be treated as `vue-html` language

### DIFF
--- a/server/src/modes/embeddedSupport.ts
+++ b/server/src/modes/embeddedSupport.ts
@@ -145,6 +145,9 @@ function scanTemplateRegion (scanner: Scanner, text: string): EmbeddedRegion | n
 
 function getLanguageIdFromLangAttr (lang: string): string {
   let languageIdFromType = removeQuotes(lang);
+  if (languageIdFromType === 'html') {
+    languageIdFromType = 'vue-html';
+  }
   if (languageIdFromType === 'jade') {
     languageIdFromType = 'pug';
   }


### PR DESCRIPTION
Currently, if the user explicitly write `lang="html"` on `<template>` element in a SFC, Vetur seems to treat it as normal `html`.
This patch let Vetur to treat it as `vue-html` which is as same behavior as when the user omit the `lang` attribute