### PR TITLE
improve template region detection

### DIFF
--- a/server/src/modes/embeddedSupport.ts
+++ b/server/src/modes/embeddedSupport.ts
@@ -137,6 +137,9 @@ function scanTemplateRegion (scanner: Scanner, text: string): EmbeddedRegion | n
         unClosedTemplate++;
       } else if (token === TokenType.EndTag && scanner.getTokenText() === 'template') {
         unClosedTemplate--;
+        if (isLeadingTemplateEnd()) {
+          break;
+        }
       } else if (token === TokenType.Unknown) {
         if (scanner.getTokenText().charAt(0) === '<') {
           const offset = scanner.getTokenOffset();
@@ -144,9 +147,20 @@ function scanTemplateRegion (scanner: Scanner, text: string): EmbeddedRegion | n
           if (unknownText === '</template>') {
             unClosedTemplate--;
           }
+          if (isLeadingTemplateEnd) {
+            break;
+          }
         }
       }
     }
+  }
+
+  // leading `</template>` means end of template
+  function isLeadingTemplateEnd() {
+    const offset = scanner.getTokenOffset();
+    // should work for both line separator
+    // -2 for </, -1 for line break
+    return text[offset - 3] === '\n';
   }
 
   // In EndTag, find end

--- a/server/src/modes/test/region.test.ts
+++ b/server/src/modes/test/region.test.ts
@@ -183,4 +183,8 @@ suite('Embedded Support', () => {
       .script('').style('')
     .template(`<div></d`)
     .run();
+
+  testcase('ill formed template10')
+    .template(`<div><template>`)
+    .run();
 });


### PR DESCRIPTION
A leading </template> indicates region ending, partially fix #367 