### PR TITLE
add integration test for vls service

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,10 +29,12 @@
     "vue-onsenui-helper-json": "^1.0.0"
   },
   "devDependencies": {
+    "@types/glob": "^5.0.30",
     "@types/js-beautify": "0.0.30",
     "@types/lodash": "^4.14.66",
     "@types/mocha": "^2.2.41",
     "@types/node": "^6.0.77",
+    "glob": "^7.1.2",
     "mocha": "^3.4.2",
     "source-map-support": "^0.4.15"
   },

--- a/server/src/service/test.ts
+++ b/server/src/service/test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as glob from 'glob';
+import * as fs from 'fs';
+import { TextDocument } from 'vscode-languageserver-types';
+import Uri from 'vscode-uri';
+
+import { getVls } from './index';
+
+const vls = getVls();
+
+const workspace = path.resolve(__dirname, '../../test/fixtures/');
+vls.initialize(workspace);
+
+suite('integrated test', () => {
+  test('validation', done => {
+    glob(workspace + '/**/*.vue', (err, filenames) => {
+      if (err) {
+        assert(false, 'error occured!' + err.toString());
+      }
+      for (const filename of filenames) {
+        const doc = createTextDocument(filename);
+        const diagnostics = vls.validate(doc);
+        assert(diagnostics.length === 0);
+      }
+      done();
+    });
+  });
+});
+
+function createTextDocument(filename: string): TextDocument {
+  const uri = Uri.file(filename).toString();
+  const content = fs.readFileSync(filename, 'utf-8');
+  return TextDocument.create(uri, 'vue', 0, content);
+}

--- a/server/test/fixtures/app.vue
+++ b/server/test/fixtures/app.vue
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
 import Comp from './component/comp.vue';
 import Comp2 from '@comp/comp.vue';
 import test from 'mod';

--- a/server/test/fixtures/app.vue
+++ b/server/test/fixtures/app.vue
@@ -1,0 +1,10 @@
+<script lang="typescript">
+import Comp from './component/comp.vue';
+import Comp2 from '@comp/comp.vue';
+import test from 'mod';
+
+Comp.data();
+Comp2.data();
+test.test.toFixed();
+myGlobal.toFixed();
+</script>

--- a/server/test/fixtures/component/comp.vue
+++ b/server/test/fixtures/component/comp.vue
@@ -1,0 +1,9 @@
+<script lang="typescript">
+export default {
+  data(): any {
+    return {
+      test: 123
+    };
+  }
+};
+</script>

--- a/server/test/fixtures/component/comp.vue
+++ b/server/test/fixtures/component/comp.vue
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
 export default {
   data(): any {
     return {

--- a/server/test/fixtures/node_modules/@types/global/index.d.ts
+++ b/server/test/fixtures/node_modules/@types/global/index.d.ts
@@ -1,0 +1,1 @@
+declare var myGlobal: number;

--- a/server/test/fixtures/node_modules/@types/mod/index.d.ts
+++ b/server/test/fixtures/node_modules/@types/mod/index.d.ts
@@ -1,0 +1,4 @@
+declare var test: {
+  test: number
+};
+export default test;

--- a/server/test/fixtures/tsconfig.json
+++ b/server/test/fixtures/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@comp/*": ["./component/*"]
+    }
+  }
+}

--- a/server/test/mocha.opts
+++ b/server/test/mocha.opts
@@ -4,3 +4,4 @@
 ./dist/modes/template/test
 ./dist/modes/style/stylus/test
 ./dist/modes/test/
+./dist/service/

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@types/glob@^5.0.30":
+  version "5.0.30"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.30.tgz#1026409c5625a8689074602808d082b2867b8a51"
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/js-beautify@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/js-beautify/-/js-beautify-0.0.30.tgz#82ffbeb2c2dec592f1d04169e926912eeed567ec"
@@ -10,11 +17,15 @@
   version "4.14.66"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.66.tgz#3dbb83477becf130611f8fac82a8fdb199805981"
 
+"@types/minimatch@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.0.tgz#a8b68c324817169b6004b432a598478a5d8f025a"
+
 "@types/mocha@^2.2.41":
   version "2.2.41"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.41.tgz#e27cf0817153eb9f2713b2d3f6c68f1e1c3ca608"
 
-"@types/node@^6.0.46", "@types/node@^6.0.77":
+"@types/node@*", "@types/node@^6.0.46", "@types/node@^6.0.77":
   version "6.0.78"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.78.tgz#5d4a3f579c1524e01ee21bf474e6fba09198f470"
 


### PR DESCRIPTION
This pull request add tests for language service host. Fix #356 .

vls.validate(doc) is very slow. I will look at how to improve it.