### PR TITLE
fix #348, optimize single file CPU usage

### DIFF
--- a/server/src/modes/languageModes.ts
+++ b/server/src/modes/languageModes.ts
@@ -47,7 +47,7 @@ export interface LanguageModeRange extends Range {
   attributeValue?: boolean;
 }
 
-export function getLanguageModes(workspacePath: string): LanguageModes {
+export function getLanguageModes(workspacePath: string | null | undefined): LanguageModes {
   const documentRegions = getLanguageModelCache<VueDocumentRegions>(10, 60, document => getDocumentRegions(document));
 
   let modelCaches: LanguageModelCache<any>[] = [];

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -10,13 +10,16 @@ import Uri from 'vscode-uri';
 import * as ts from 'typescript';
 import * as _ from 'lodash';
 
-import { NULL_SIGNATURE, NULL_COMPLETION } from '../nullMode';
+import { nullMode, NULL_SIGNATURE, NULL_COMPLETION } from '../nullMode';
 
 export interface ScriptMode extends LanguageMode {
   findComponents(document: TextDocument): ComponentInfo[];
 }
 
-export function getJavascriptMode(documentRegions: LanguageModelCache<VueDocumentRegions>, workspacePath: string): ScriptMode {
+export function getJavascriptMode(documentRegions: LanguageModelCache<VueDocumentRegions>, workspacePath: string | null | undefined): ScriptMode {
+  if (!workspacePath) {
+    return { ...nullMode, findComponents: () => [] };
+  }
   const jsDocuments = getLanguageModelCache(10, 60, document => {
     const vueDocument = documentRegions.get(document);
     return vueDocument.getEmbeddedDocumentByType('script');

--- a/server/src/modes/template/index.ts
+++ b/server/src/modes/template/index.ts
@@ -21,7 +21,7 @@ type DocumentRegionCache = LanguageModelCache<VueDocumentRegions>;
 
 export function getVueHTMLMode(
   documentRegions: DocumentRegionCache,
-  workspacePath: string,
+  workspacePath: string | null | undefined,
   scriptMode: ScriptMode): LanguageMode {
   let settings: any = {};
   let completionOption = getDefaultSetting(workspacePath);

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -29,7 +29,7 @@ export function getBasicTagProviders(setting: CompletionConfiguration) {
   );
 }
 
-export function getDefaultSetting(workspacePath: string) {
+export function getDefaultSetting(workspacePath: string | null | undefined) {
   const setting: CompletionConfiguration = {
     html5: true,
     vue: true,
@@ -37,6 +37,9 @@ export function getDefaultSetting(workspacePath: string) {
     element: false,
     onsen: false
   };
+  if (!workspacePath) {
+    return setting;
+  }
   try {
     const packagePath = ts.findConfigFile(workspacePath, ts.sys.fileExists, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -25,7 +25,7 @@ export interface DocumentContext {
 }
 
 export interface VLS {
-  initialize(workspacePath: string): void;
+  initialize(workspacePath: string | null | undefined): void;
   configure(settings: any): void;
   format(doc: TextDocument, range: Range, formattingOptions: FormattingOptions): TextEdit[];
   validate(doc: TextDocument): Diagnostic[];

--- a/server/src/vueServerMain.ts
+++ b/server/src/vueServerMain.ts
@@ -25,7 +25,7 @@ const documents = new TextDocuments();
 // for open, change and close text document events
 documents.listen(connection);
 
-let workspacePath: string;
+let workspacePath: string | null | undefined;
 let settings: any = {};
 const vls = getVls();
 
@@ -37,7 +37,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
   console.log('vetur initialized');
   const initializationOptions = params.initializationOptions;
 
-  workspacePath = params.rootPath || process.cwd();
+  workspacePath = params.rootPath;
   vls.initialize(workspacePath);
 
   documents.onDidClose(e => {


### PR DESCRIPTION
If we cannot find out workpath, just disable some feature.

Currently, process.cwd() will return either home dir or root dir. This hangs vetur as whole. If we just disable script service, at least some completion service works.