### PR TITLE
[WIP] Support Vue 2.5 types

### DIFF
--- a/server/src/modes/script/bridge.ts
+++ b/server/src/modes/script/bridge.ts
@@ -6,8 +6,8 @@ export const moduleName = 'vue-editor-bridge';
 export const fileName = 'vue-temp/vue-editor-bridge.ts';
 
 export const content = `
-import Vue from 'vue';
-export interface GeneralOption extends Vue.ComponentOptions<Vue> {
+import Vue, { ComponentOptions } from 'vue';
+export interface GeneralOption extends ComponentOptions<Vue> {
   [key: string]: any
 }
 export default function test<T>(t: T & GeneralOption): T {

--- a/server/src/modes/script/preprocess.ts
+++ b/server/src/modes/script/preprocess.ts
@@ -47,10 +47,11 @@ function modifyVueSource(sourceFile: ts.SourceFile): void {
     // 1. add `import Vue from 'vue'
     //    (the span of the inserted statement must be (0,0) to avoid overlapping existing statements)
     const setZeroPos = getWrapperRangeSetter({ pos: 0, end: 0 });
-    const vueImport = setZeroPos(ts.createImportDeclaration(undefined,
+    const vueImport = setZeroPos(ts.createImportDeclaration(
       undefined,
-      setZeroPos(ts.createImportClause(ts.createIdentifier('__vueEditorBridge'), undefined as any)), // TODO: remove this after 2.4
-      setZeroPos(ts.createLiteral('vue-editor-bridge'))));
+      undefined,
+      setZeroPos(ts.createImportClause(ts.createIdentifier('Vue'), undefined as any)), // TODO: remove this after 2.4
+      setZeroPos(ts.createLiteral('vue'))));
     const statements: Array<ts.Statement> = sourceFile.statements as any;
     statements.unshift(vueImport);
 
@@ -58,9 +59,9 @@ function modifyVueSource(sourceFile: ts.SourceFile): void {
     //    (the span of the function construct call and *all* its members must be the same as the object literal it wraps)
     const objectLiteral = (exportDefaultObject as ts.ExportAssignment).expression as ts.ObjectLiteralExpression;
     const setObjPos = getWrapperRangeSetter(objectLiteral);
-    const vue = ts.setTextRange(ts.createIdentifier('__vueEditorBridge'), { pos: objectLiteral.pos, end: objectLiteral.pos + 1 });
-    (exportDefaultObject as ts.ExportAssignment).expression = setObjPos(ts.createCall(vue, undefined, [objectLiteral]));
-    setObjPos(((exportDefaultObject as ts.ExportAssignment).expression as ts.CallExpression).arguments!);
+    const vue = ts.setTextRange(ts.createIdentifier('Vue'), { pos: objectLiteral.pos, end: objectLiteral.pos + 1 });
+    (exportDefaultObject as ts.ExportAssignment).expression = setObjPos(ts.createNew(vue, undefined, [objectLiteral]));
+    setObjPos(((exportDefaultObject as ts.ExportAssignment).expression as ts.NewExpression).arguments!);
   }
 }
 


### PR DESCRIPTION
I know this causes test failing. Just a starting point.

@HerringtonDarkholme
I'm not 100% sure I'm doing the right thing, so here are some questions looking for your feedback:

1. Thinking we should provide a setting like `vetur.experimental.newType` which is
    - false by default
    - if turned on, works with Vue / Vuex / Vue-Router 2.5+

2. What is `GeneralOption` initially for? Do we still need it and the `test` for 2.5?
3. What's your reasoning for replacing `ts.createNew` with `ts.createCall`?
4. Do we still need the `vue-editor-bridge` for 2.5+?

Here is the repo I'm testing against: https://github.com/octref/TypeScript-Vue-Starter
Pulling dependency from your branch and @ktsn's vuex branch.