### PR TITLE
support Vue 2.5+ typing

### DIFF
--- a/server/src/modes/script/bridge.ts
+++ b/server/src/modes/script/bridge.ts
@@ -5,11 +5,17 @@ export const moduleName = 'vue-editor-bridge';
 
 export const fileName = 'vue-temp/vue-editor-bridge.ts';
 
-export const content = `
+export const oldContent = `
 import Vue from 'vue';
 export interface GeneralOption extends Vue.ComponentOptions<Vue> {
-  [key: string]: any
+  [key: string]: any;
 }
-export default function test<T>(t: T & GeneralOption): T {
-  return t
+export default function bridge<T>(t: T & GeneralOption): T {
+  return t;
 }`;
+
+export const content = `
+import Vue from 'vue';
+const func = Vue.extend;
+export default func;
+`;

--- a/server/src/modes/script/serviceHost.ts
+++ b/server/src/modes/script/serviceHost.ts
@@ -67,7 +67,7 @@ function inferIsOldVersion(workspacePath: string): boolean {
     const sloppyVersion = parseFloat(vueDep);
     return sloppyVersion < 2.5;
   } catch (e) {
-    return false;
+    return true;
   }
 }
 

--- a/server/src/modes/script/serviceHost.ts
+++ b/server/src/modes/script/serviceHost.ts
@@ -58,6 +58,19 @@ function getScriptKind(langId: string): ts.ScriptKind {
     : ts.ScriptKind.JS;
 }
 
+function inferIsOldVersion(workspacePath: string): boolean {
+  const packageJSONPath = ts.findConfigFile(workspacePath, ts.sys.fileExists, 'package.json');
+  try {
+    const packageJSON = packageJSONPath && JSON.parse(ts.sys.readFile(packageJSONPath)!);
+    // use a sloppy method to infer version, to reduce dep on semver or so
+    const vueDep = packageJSON.dependencies.vue.match(/\d+\.\d+/)[0];
+    const sloppyVersion = parseFloat(vueDep);
+    return sloppyVersion < 2.5;
+  } catch (e) {
+    return false;
+  }
+}
+
 export function getServiceHost(workspacePath: string, jsDocuments: LanguageModelCache<TextDocument>) {
   let compilerOptions: ts.CompilerOptions = {
     allowNonTsExtensions: true,
@@ -91,6 +104,7 @@ export function getServiceHost(workspacePath: string, jsDocuments: LanguageModel
     undefined,
     [{ extension: 'vue', isMixedContent: true }]);
   const files = parsedConfig.fileNames;
+  const isOldVersion = inferIsOldVersion(workspacePath);
   compilerOptions = parsedConfig.options;
   compilerOptions.allowNonTsExtensions = true;
 
@@ -191,7 +205,7 @@ export function getServiceHost(workspacePath: string, jsDocuments: LanguageModel
     },
     getScriptSnapshot: (fileName: string) => {
       if (fileName === bridge.fileName) {
-        const text = bridge.content;
+        const text = isOldVersion ? bridge.oldContent : bridge.content;
         return {
           getText: (start, end) => text.substring(start, end),
           getLength: () => text.length,

--- a/server/test/fixtures/package.json
+++ b/server/test/fixtures/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fixtures",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "vue": "^2.4.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This is a simple and easy fix. 

We still have chances to improve.

Playground: https://github.com/octref/TypeScript-Vue-Starter