### PR TITLE
Fix Typo

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -7,7 +7,7 @@ We plan to switch to [prettier](https://github.com/prettier/prettier) soon.
 
 ## General
 
-`tabSize` and `insertSpace` are read from VSCode config `editor.tabSize` and `editor.insertSpace`.  
+`tabSize` and `insertSpaces` are read from VSCode config `editor.tabSize` and `editor.insertSpaces`.  
 Two space soft-tab is recommended for all languages.
 
 ## `html/css/scss/less`


### PR DESCRIPTION
It's `editor.insertSpaces`. 
P.S: I should see that option around [here](https://github.com/vuejs/vetur/blob/master/server/src/modes/script/javascript.ts#L398) buh it isn't there???