### PR TITLE
feat: better javascript completion order

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -100,13 +100,13 @@ export function getJavascriptMode(
       const entries = completions.entries.filter(entry => entry.name !== '__vueEditorBridge');
       return {
         isIncomplete: false,
-        items: entries.map(entry => {
+        items: entries.map((entry, index) => {
           const range = entry.replacementSpan && convertRange(scriptDoc, entry.replacementSpan);
           return {
             uri: doc.uri,
             position,
             label: entry.name,
-            sortText: entry.sortText,
+            sortText: entry.sortText + index,
             kind: convertKind(entry.kind),
             textEdit: range && TextEdit.replace(range, entry.name),
             data: {


### PR DESCRIPTION
Before:

<img width="397" alt="screen shot 2017-10-16 at 10 51 30 am" src="https://user-images.githubusercontent.com/2883231/31814212-84b06906-b54e-11e7-8fbe-07c93b223873.png">

After:

<img width="811" alt="screen shot 2017-10-20 at 4 52 38 pm" src="https://user-images.githubusercontent.com/2883231/31814227-8cd7ca52-b54e-11e7-8f66-d5e775a8d534.png">

We also need to change Vue's definition file. The screen is captured after local edit to definition file.
cc @octref 