### PR TITLE
Upgraded Stylus Supremacy to version 2.5.0. Fix #471

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "parse-gitignore": "^0.4.0",
     "prettier": "^1.7.4",
     "stylus": "^0.54.5",
-    "stylus-supremacy": "~2.4.0",
+    "stylus-supremacy": "~2.5.0",
     "typescript": "2.5.3",
     "vscode-css-languageservice": "^2.0.0",
     "vscode-emmet-helper": "^1.0.19",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1938,9 +1938,9 @@ stylint@^1.5.9:
     user-home "2.0.0"
     yargs "4.7.1"
 
-stylus-supremacy@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.4.0.tgz#7a7b081539ed53cc5adca4aa400c5be76c30909a"
+stylus-supremacy@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.5.0.tgz#a01da56efdad8070d3d47aa3f435078bc1f794eb"
   dependencies:
     comment-json "^1.1.3"
     glob "^7.1.2"


### PR DESCRIPTION
The new version of Stylus Supremacy addresses [these issues](https://github.com/ThisIsManta/stylus-supremacy/releases/tag/v2.5.0) reported in https://github.com/vuejs/vetur/issues/471.