### PR TITLE
Upgraded Stylus Supremacy to version 2.5.1

### DIFF
--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -34,8 +34,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.78.tgz#5d4a3f579c1524e01ee21bf474e6fba09198f470"
 
 abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -1614,8 +1614,8 @@ randomatic@^1.1.3:
     kind-of "^4.0.0"
 
 rc@^1.1.7:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -1939,8 +1939,8 @@ stylint@^1.5.9:
     yargs "4.7.1"
 
 stylus-supremacy@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.5.0.tgz#a01da56efdad8070d3d47aa3f435078bc1f794eb"
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.5.1.tgz#909cd2e999874ae39e8d4f7b6047d8b4225f8292"
   dependencies:
     comment-json "^1.1.3"
     glob "^7.1.2"


### PR DESCRIPTION
This addresses [this issue](https://github.com/ThisIsManta/stylus-supremacy/issues/9#issuecomment-338447458).
https://github.com/ThisIsManta/stylus-supremacy/releases/tag/v2.5.1