### PR TITLE
Refactor component analysis

### DIFF
--- a/server/src/modes/script/findComponents.ts
+++ b/server/src/modes/script/findComponents.ts
@@ -75,17 +75,10 @@ function getCompInfo(symbol: ts.Symbol, checker: ts.TypeChecker) {
   if (!declaration) {
     return info;
   }
-  let compExpr: ts.Expression | undefined;
+  let compExpr: ts.Node = declaration;
   if (declaration.kind === ts.SyntaxKind.ExportAssignment) {
-    compExpr = (declaration as ts.ExportAssignment).expression;
-    compExpr = getComponentFromExport(compExpr);
-  } else if (declaration.kind === ts.SyntaxKind.PropertyAssignment) {
-    compExpr = (declaration as ts.PropertyAssignment).initializer;
-  } else if (declaration.kind === ts.SyntaxKind.VariableDeclaration) {
-    compExpr = (declaration as ts.VariableDeclaration).initializer;
-  }
-  if (!compExpr) {
-    return info;
+    const expr = (declaration as ts.ExportAssignment).expression;
+    compExpr = getComponentFromExport(expr) || declaration;
   }
   const compType = checker.getTypeAtLocation(compExpr);
   const arrayProps = getArrayProps(compType, checker);

--- a/server/src/modes/script/findComponents.ts
+++ b/server/src/modes/script/findComponents.ts
@@ -81,6 +81,8 @@ function getCompInfo(symbol: ts.Symbol, checker: ts.TypeChecker) {
     compExpr = getComponentFromExport(compExpr);
   } else if (declaration.kind === ts.SyntaxKind.PropertyAssignment) {
     compExpr = (declaration as ts.PropertyAssignment).initializer;
+  } else if (declaration.kind === ts.SyntaxKind.VariableDeclaration) {
+    compExpr = (declaration as ts.VariableDeclaration).initializer;
   }
   if (!compExpr) {
     return info;

--- a/server/src/modes/script/test.ts
+++ b/server/src/modes/script/test.ts
@@ -1,50 +1,52 @@
-// import * as assert from 'assert';
-// import * as path from 'path';
-// import * as glob from 'glob';
-// import * as fs from 'fs';
-// import { TextDocument } from 'vscode-languageserver-types';
-// import Uri from 'vscode-uri';
+import * as assert from 'assert';
+import * as path from 'path';
+import * as glob from 'glob';
+import * as fs from 'fs';
+import { TextDocument } from 'vscode-languageserver-types';
+import Uri from 'vscode-uri';
 
-// import { getJavascriptMode } from './javascript';
-// import { getLanguageModelCache } from '../languageModelCache';
-// import { getDocumentRegions } from '../embeddedSupport';
-// import { ComponentInfo } from './findComponents';
+import { getJavascriptMode } from './javascript';
+import { getLanguageModelCache } from '../languageModelCache';
+import { getDocumentRegions } from '../embeddedSupport';
+import { ComponentInfo } from './findComponents';
 
-// const workspace = path.resolve(__dirname, '../../../test/fixtures/');
-// const documentRegions = getLanguageModelCache(10, 60, document => getDocumentRegions(document));
-// const scriptMode = getJavascriptMode(documentRegions, workspace);
+const workspace = path.resolve(__dirname, '../../../test/fixtures/');
+const documentRegions = getLanguageModelCache(10, 60, document => getDocumentRegions(document));
+const scriptMode = getJavascriptMode(documentRegions, workspace);
 
-// suite('integrated test', () => {
-//   const filenames = glob.sync(workspace + '/**/*.vue');
-//   for (const filename of filenames) {
-//     const doc = createTextDocument(filename);
-//     const diagnostics = scriptMode.doValidation!(doc);
-//     test('validate: ' + path.basename(filename), () => {
-//       assert(diagnostics.length === 0);
-//     });
-//     if (filename.endsWith('app.vue')) {
-//       const components = scriptMode.findComponents(doc);
-//       test('props collection', testProps.bind(null, components));
-//     }
-//   }
-// });
+suite('integrated test', () => {
+  const filenames = glob.sync(workspace + '/**/*.vue');
+  for (const filename of filenames) {
+    const doc = createTextDocument(filename);
+    const diagnostics = scriptMode.doValidation!(doc);
+    test('validate: ' + path.basename(filename), () => {
+      assert(diagnostics.length === 0);
+    });
+    if (filename.endsWith('app.vue')) {
+      const components = scriptMode.findComponents(doc);
+      test('props collection', testProps.bind(null, components));
+    }
+  }
+});
 
-// function testProps(components: ComponentInfo[]) {
-//   assert.equal(components.length, 2, 'component number');
-//   const comp = components[0];
-//   const comp2 = components[1];
-//   assert.equal(comp.name, 'comp', 'component name');
-//   assert.equal(comp2.name, 'comp2', 'component name');
-//   assert.deepEqual(comp.props, [{ name: 'propname' }, { name: 'another-prop' }]);
-//   assert.deepEqual(comp2.props, [
-//     { name: 'propname', doc: 'String' },
-//     { name: 'weird-prop', doc: '' },
-//     { name: 'another-prop', doc: 'type: Number' }
-//   ]);
-// }
+function testProps(components: ComponentInfo[]) {
+  assert.equal(components.length, 4, 'component number');
+  const comp = components[0];
+  const comp2 = components[1];
+  const comp3 = components[2];
+  assert.equal(comp.name, 'comp', 'component name');
+  assert.equal(comp2.name, 'comp2', 'component name');
+  assert.deepEqual(comp.props, [{ name: 'propname' }, { name: 'another-prop' }]);
+  assert.deepEqual(comp2.props, [
+    { name: 'propname', doc: 'String' },
+    { name: 'weird-prop', doc: '' },
+    { name: 'another-prop', doc: 'type: Number' }
+  ]);
+  assert.deepEqual(comp3.props, [{ name: 'inline' }]);
+}
 
-// function createTextDocument(filename: string): TextDocument {
-//   const uri = Uri.file(filename).toString();
-//   const content = fs.readFileSync(filename, 'utf-8');
-//   return TextDocument.create(uri, 'vue', 0, content);
-// }
+function createTextDocument(filename: string): TextDocument {
+  const uri = Uri.file(filename).toString();
+  const content = fs.readFileSync(filename, 'utf-8');
+  return TextDocument.create(uri, 'vue', 0, content);
+}

--- a/server/src/modes/script/test.ts
+++ b/server/src/modes/script/test.ts
@@ -1,50 +1,50 @@
-import * as assert from 'assert';
-import * as path from 'path';
-import * as glob from 'glob';
-import * as fs from 'fs';
-import { TextDocument } from 'vscode-languageserver-types';
-import Uri from 'vscode-uri';
+// import * as assert from 'assert';
+// import * as path from 'path';
+// import * as glob from 'glob';
+// import * as fs from 'fs';
+// import { TextDocument } from 'vscode-languageserver-types';
+// import Uri from 'vscode-uri';
 
-import { getJavascriptMode } from './javascript';
-import { getLanguageModelCache } from '../languageModelCache';
-import { getDocumentRegions } from '../embeddedSupport';
-import { ComponentInfo } from './findComponents';
+// import { getJavascriptMode } from './javascript';
+// import { getLanguageModelCache } from '../languageModelCache';
+// import { getDocumentRegions } from '../embeddedSupport';
+// import { ComponentInfo } from './findComponents';
 
-const workspace = path.resolve(__dirname, '../../../test/fixtures/');
-const documentRegions = getLanguageModelCache(10, 60, document => getDocumentRegions(document));
-const scriptMode = getJavascriptMode(documentRegions, workspace);
+// const workspace = path.resolve(__dirname, '../../../test/fixtures/');
+// const documentRegions = getLanguageModelCache(10, 60, document => getDocumentRegions(document));
+// const scriptMode = getJavascriptMode(documentRegions, workspace);
 
-suite('integrated test', () => {
-  const filenames = glob.sync(workspace + '/**/*.vue');
-  for (const filename of filenames) {
-    const doc = createTextDocument(filename);
-    const diagnostics = scriptMode.doValidation!(doc);
-    test('validate: ' + path.basename(filename), () => {
-      assert(diagnostics.length === 0);
-    });
-    if (filename.endsWith('app.vue')) {
-      const components = scriptMode.findComponents(doc);
-      test('props collection', testProps.bind(null, components));
-    }
-  }
-});
+// suite('integrated test', () => {
+//   const filenames = glob.sync(workspace + '/**/*.vue');
+//   for (const filename of filenames) {
+//     const doc = createTextDocument(filename);
+//     const diagnostics = scriptMode.doValidation!(doc);
+//     test('validate: ' + path.basename(filename), () => {
+//       assert(diagnostics.length === 0);
+//     });
+//     if (filename.endsWith('app.vue')) {
+//       const components = scriptMode.findComponents(doc);
+//       test('props collection', testProps.bind(null, components));
+//     }
+//   }
+// });
 
-function testProps(components: ComponentInfo[]) {
-  assert.equal(components.length, 2, 'component number');
-  const comp = components[0];
-  const comp2 = components[1];
-  assert.equal(comp.name, 'comp', 'component name');
-  assert.equal(comp2.name, 'comp2', 'component name');
-  assert.deepEqual(comp.props, [{ name: 'propname' }, { name: 'another-prop' }]);
-  assert.deepEqual(comp2.props, [
-    { name: 'propname', doc: 'String' },
-    { name: 'weird-prop', doc: '' },
-    { name: 'another-prop', doc: 'type: Number' }
-  ]);
-}
+// function testProps(components: ComponentInfo[]) {
+//   assert.equal(components.length, 2, 'component number');
+//   const comp = components[0];
+//   const comp2 = components[1];
+//   assert.equal(comp.name, 'comp', 'component name');
+//   assert.equal(comp2.name, 'comp2', 'component name');
+//   assert.deepEqual(comp.props, [{ name: 'propname' }, { name: 'another-prop' }]);
+//   assert.deepEqual(comp2.props, [
+//     { name: 'propname', doc: 'String' },
+//     { name: 'weird-prop', doc: '' },
+//     { name: 'another-prop', doc: 'type: Number' }
+//   ]);
+// }
 
-function createTextDocument(filename: string): TextDocument {
-  const uri = Uri.file(filename).toString();
-  const content = fs.readFileSync(filename, 'utf-8');
-  return TextDocument.create(uri, 'vue', 0, content);
-}
+// function createTextDocument(filename: string): TextDocument {
+//   const uri = Uri.file(filename).toString();
+//   const content = fs.readFileSync(filename, 'utf-8');
+//   return TextDocument.create(uri, 'vue', 0, content);
+// }

--- a/server/src/modes/script/test.ts
+++ b/server/src/modes/script/test.ts
@@ -34,6 +34,7 @@ function testProps(components: ComponentInfo[]) {
   const comp = components[0];
   const comp2 = components[1];
   const comp3 = components[2];
+  const comp4 = components[3];
   assert.equal(comp.name, 'comp', 'component name');
   assert.equal(comp2.name, 'comp2', 'component name');
   assert.deepEqual(comp.props, [{ name: 'propname' }, { name: 'another-prop' }]);
@@ -43,6 +44,7 @@ function testProps(components: ComponentInfo[]) {
     { name: 'another-prop', doc: 'type: Number' }
   ]);
   assert.deepEqual(comp3.props, [{ name: 'inline' }]);
+  assert.deepEqual(comp4.props, [{ name: 'inline', doc: 'Number' }]);
 }
 
 function createTextDocument(filename: string): TextDocument {

--- a/server/test/fixtures/app.vue
+++ b/server/test/fixtures/app.vue
@@ -8,7 +8,9 @@ Comp2.props;
 test.test.toFixed();
 myGlobal.toFixed();
 
-const Comp4 = { props: ['inline'] };
+const Comp4 = {
+  props: { inline: Number }
+};
 
 export default {
   components: {

--- a/server/test/fixtures/app.vue
+++ b/server/test/fixtures/app.vue
@@ -8,9 +8,16 @@ Comp2.props;
 test.test.toFixed();
 myGlobal.toFixed();
 
+const Comp4 = { props: ['inline'] };
+
 export default {
   components: {
-    Comp, Comp2
+    Comp: Comp,
+    Comp2,
+    Comp3: {
+      props: ['inline']
+    },
+    Comp4
   }
 }
 </script>

--- a/server/test/fixtures/component/comp2.vue
+++ b/server/test/fixtures/component/comp2.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 const weirdProp = String;
-export default {
+import Vue from 'vue';
+export default Vue.extend({
   props: {
     propname: String,
     weirdProp,
@@ -8,5 +9,5 @@ export default {
       type: Number,
     }
   }
-};
+});
 </script>

--- a/server/test/fixtures/node_modules/@types/vue/index.d.ts
+++ b/server/test/fixtures/node_modules/@types/vue/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'vue' {
+  var exp: any;
+  export default exp;
+}


### PR DESCRIPTION
Fix #502 
This pull request also skips wrapping ts script object, so vetur and ts-loader will align.

The component analysis combines both AST traversal and type checking. More specifically, we only do type analysis on the definition object literal, e.g the argument of `Vue.extend`, which is found by AST traversal.

This approach is independent of Vue's type declaration. So both Vue2.4- and 2.5+ are supported.