### PR TITLE
Feature: Merge lib options from tsconfig

### DIFF
--- a/server/src/modes/script/serviceHost.ts
+++ b/server/src/modes/script/serviceHost.ts
@@ -106,17 +106,17 @@ export function getServiceHost(workspacePath: string, jsDocuments: LanguageModel
     undefined,
     [{ extension: 'vue', isMixedContent: true }]);
   const files = parsedConfig.fileNames;
-  const raw = parsedConfig.raw
+  const raw = parsedConfig.raw;
   const isOldVersion = inferIsOldVersion(workspacePath);
   compilerOptions = parsedConfig.options;
   compilerOptions.allowNonTsExtensions = true;
   compilerOptions.lib = (raw.compilerOptions && raw.compilerOptions.lib) || compilerOptions.lib;
   compilerOptions.lib = compilerOptions.lib.map((item) => {
     if (item.startsWith('lib.') && item.endsWith('.d.ts')) {
-      return item
+      return item;
     }
-    return `lib.${item}.d.ts`
-  })
+    return `lib.${item}.d.ts`;
+  });
 
 
   function updateCurrentTextDocument(doc: TextDocument) {

--- a/server/src/modes/script/serviceHost.ts
+++ b/server/src/modes/script/serviceHost.ts
@@ -106,9 +106,18 @@ export function getServiceHost(workspacePath: string, jsDocuments: LanguageModel
     undefined,
     [{ extension: 'vue', isMixedContent: true }]);
   const files = parsedConfig.fileNames;
+  const raw = parsedConfig.raw
   const isOldVersion = inferIsOldVersion(workspacePath);
   compilerOptions = parsedConfig.options;
   compilerOptions.allowNonTsExtensions = true;
+  compilerOptions.lib = (raw.compilerOptions && raw.compilerOptions.lib) || compilerOptions.lib;
+  compilerOptions.lib = compilerOptions.lib.map((item) => {
+    if (item.startsWith('lib.') && item.endsWith('.d.ts')) {
+      return item
+    }
+    return `lib.${item}.d.ts`
+  })
+
 
   function updateCurrentTextDocument(doc: TextDocument) {
     const fileFsPath = getFileFsPath(doc.uri);


### PR DESCRIPTION
= Problem

Lib options are not prioritised from users tsconfig, thus meaning the TS in vue files have different typing rules compared to TS config. 

For example a user may want to have `dom.iterable` enabled in lib options.

![screenshot from 2017-11-02 10-22-25](https://user-images.githubusercontent.com/7272211/32321082-d875d9c2-bfb7-11e7-985a-2c4677697190.png)


= Solution
- Take lib options from tsconfig.json as a priority if existing
- Map results into tsc compiler friendly values

![screenshot from 2017-11-02 10-21-57](https://user-images.githubusercontent.com/7272211/32321088-ddbd9654-bfb7-11e7-93e0-402fd53a4988.png)
