### PR TITLE
chore(server): update bootstrap-vue dep for v1.0.2

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "bin"
   ],
   "dependencies": {
-    "bootstrap-vue-helper-json": "^1.0.1",
+    "bootstrap-vue-helper-json": "^1.1.1",
     "element-helper-json": "^1.0.0",
     "eslint": "^4.5.0",
     "eslint-plugin-vue": "3.13.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -230,9 +230,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap-vue-helper-json@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bootstrap-vue-helper-json/-/bootstrap-vue-helper-json-1.0.2.tgz#17dca204a7824ec6a15add41e83f69762219d99d"
+bootstrap-vue-helper-json@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-vue-helper-json/-/bootstrap-vue-helper-json-1.1.1.tgz#fca94c9d6c73774d5f2b69183cf135b758398068"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
BootstrapVue recently hit a 1.0.0 release. This commit just bumps the pkg.json dep up to mirror the updated helpers repo.