### PR TITLE
fix: change eslint rule set and fix template wrapping error

### DIFF
--- a/server/src/modes/template/services/htmlValidation.ts
+++ b/server/src/modes/template/services/htmlValidation.ts
@@ -22,7 +22,7 @@ export function doValidation(document: TextDocument, engine: CLIEngine): Diagnos
     return [];
   }
   // TODO: replace the last 11 consecutive spaces
-  const text = rawText.replace(/ {10}/, '<template>').replace(/\s{11}$/, '</template>');
+  const text = rawText.replace(/ {10}/, '<template>') + '</template>';
   const report = engine.executeOnText(text, document.uri);
 
   return report.results[0] ? report.results[0].messages.map(toDiagnostic) : [];
@@ -32,6 +32,6 @@ export function createLintEngine() {
   return new CLIEngine({
     useEslintrc: false,
     ...configs.base,
-    ...configs.recommended
+    ...configs.essential
   });
 }


### PR DESCRIPTION
@octref 

This change will make vetur only report `essential` category errors.