### PR TITLE
Print e.message instead of e for prettier format errors

### DIFF
--- a/server/src/utils/prettier/index.ts
+++ b/server/src/utils/prettier/index.ts
@@ -21,7 +21,7 @@ export function prettierify(
     return [toReplaceTextedit(prettierifiedCode, range, formatParams, initialIndent)];
   } catch (e) {
     console.log('Prettier format failed');
-    console.error(e);
+    console.error(e.message);
     return [];
   }
 }
@@ -46,7 +46,7 @@ export function prettierEslintify(
     return [toReplaceTextedit(prettierifiedCode, range, formatParams, initialIndent)];
   } catch (e) {
     console.log('Prettier-Eslint format failed');
-    console.error(e);
+    console.error(e.message);
     return [];
   }
 }


### PR DESCRIPTION
As shown in [this](https://github.com/vuejs/vetur/issues/477) or [this](https://github.com/vuejs/vetur/issues/574) issue report, current errors in code formatting only prints 

```
Prettier format failed
[Error - 14:06:21] [object Object]
```

which has no information. Printing actual message will be more helpful to the users and can reduce turn-taking time IMO.