### PR TITLE
add arrowParens option

### DIFF
--- a/server/src/utils/prettier/index.ts
+++ b/server/src/utils/prettier/index.ts
@@ -72,7 +72,8 @@ function getPrettierOptions(
     jsxBracketSameLine: prettierVSCodeConfig.jsxBracketSameLine,
     parser,
     semi: prettierVSCodeConfig.semi,
-    useTabs: prettierVSCodeConfig.useTabs
+    useTabs: prettierVSCodeConfig.useTabs,
+    arrowParens: prettierVSCodeConfig.arrowParens
   };
 
   const prettier = require('prettier') as Prettier;

--- a/server/src/utils/prettier/prettier.d.ts
+++ b/server/src/utils/prettier/prettier.d.ts
@@ -14,6 +14,7 @@ export interface PrettierConfig {
   parser: ParserOption;
   semi: boolean;
   useTabs: boolean;
+  arrowParens: 'avoid' | 'always';
 }
 /**
  * prettier-vscode specific configuration


### PR DESCRIPTION
I wasn't able to change the prettier arrowParens options through the vscode settings. This should fix it.