### PR TITLE
fix: allow use of markdown in completion and hover documentation

### DIFF
--- a/server/src/modes/template/services/htmlCompletion.ts
+++ b/server/src/modes/template/services/htmlCompletion.ts
@@ -6,7 +6,8 @@ import {
   Range,
   TextEdit,
   InsertTextFormat,
-  CompletionItem
+  CompletionItem,
+  MarkupKind
 } from 'vscode-languageserver-types';
 import { HTMLDocument } from '../parser/htmlParser';
 import { TokenType, createScanner, ScannerState } from '../parser/htmlScanner';
@@ -50,7 +51,7 @@ export function doComplete(
         result.items.push({
           label: tag,
           kind: CompletionItemKind.Property,
-          documentation: label,
+          documentation: { kind: MarkupKind.Markdown, value: label },
           textEdit: TextEdit.replace(range, tag),
           sortText: priority + tag,
           insertTextFormat: InsertTextFormat.PlainText
@@ -155,7 +156,7 @@ export function doComplete(
           textEdit: TextEdit.replace(range, codeSnippet),
           insertTextFormat: InsertTextFormat.Snippet,
           sortText: priority + attribute,
-          documentation
+          documentation: { kind: MarkupKind.Markdown, value: documentation || `No docs for ${attribute}` }
         });
       });
     });

--- a/server/src/modes/template/services/htmlHover.ts
+++ b/server/src/modes/template/services/htmlHover.ts
@@ -24,7 +24,7 @@ export function doHover(
       provider.collectTags((t, label) => {
         if (t === tag) {
           const tagLabel = open ? '<' + tag + '>' : '</' + tag + '>';
-          hover = { contents: [{ language: 'html', value: tagLabel }, MarkedString.fromPlainText(label)], range };
+          hover = { contents: [{ language: 'html', value: tagLabel }, label], range };
         }
       });
       if (hover) {

--- a/server/src/modes/template/test/completion.test.ts
+++ b/server/src/modes/template/test/completion.test.ts
@@ -11,6 +11,7 @@ import { CompletionTestSetup, testDSL, CompletionAsserter } from '../../test-uti
 import { parseHTMLDocument } from '../parser/htmlParser';
 import { doComplete } from '../services/htmlCompletion';
 import { allTagProviders, getEnabledTagProviders } from '../tagProviders';
+import { MarkupKind } from 'vscode-languageserver-types';
 
 const setup: CompletionTestSetup = {
   langId: 'vue-html',
@@ -22,6 +23,8 @@ const setup: CompletionTestSetup = {
 };
 
 const html = testDSL(setup);
+
+const makeDoc = (doc: string) => ({ kind: MarkupKind.Markdown, value: doc });
 
 suite('HTML Completion', () => {
   test('Complete Start Tag', () => {
@@ -353,22 +356,22 @@ suite('HTML Completion', () => {
     const noHTML = configured({ html5: false, element: true, router: false });
     noHTML`<|`
       .has('el-input')
-      .withDoc('Input data using mouse or keyboard.')
+      .withDoc(makeDoc('Input data using mouse or keyboard.'))
       .hasNo('div');
 
     noHTML`<el-input |`
       .has('placeholder')
       .hasNo('text-color')
       .has('on-icon-click')
-      .withDoc('hook function when clicking on the input icon')
+      .withDoc(makeDoc('hook function when clicking on the input icon'))
       .has('auto-complete')
       .become('<el-input auto-complete="$1"');
 
     noHTML`<el-cascader expand-trigger=|`.has('click').has('hover');
 
-    noHTML`<el-tooltip |`.has('content').withDoc('display content, can be overridden by slot#content');
+    noHTML`<el-tooltip |`.has('content').withDoc(makeDoc('display content, can be overridden by slot#content'));
 
-    noHTML`<el-popover |`.has('content').withDoc('popover content, can be replaced with a default slot');
+    noHTML`<el-popover |`.has('content').withDoc(makeDoc('popover content, can be replaced with a default slot'));
 
     const vueHTML = configured({ html5: true, element: false, router: false });
     vueHTML`<|`

--- a/server/src/modes/test-util/completion-test-util.ts
+++ b/server/src/modes/test-util/completion-test-util.ts
@@ -5,7 +5,8 @@ import {
   CompletionItemKind,
   Position,
   CompletionItem,
-  TextEdit
+  TextEdit,
+  MarkupContent
 } from 'vscode-languageserver-types';
 
 export interface CompletionTestSetup {
@@ -45,8 +46,8 @@ export class CompletionAsserter {
     this.lastMatch = matches[0];
     return this;
   }
-  withDoc(doc: string) {
-    assert.equal(this.lastMatch.documentation, doc);
+  withDoc(doc: string | MarkupContent) {
+    assert.deepEqual(this.lastMatch.documentation, doc);
     return this;
   }
   withKind(kind: CompletionItemKind) {


### PR DESCRIPTION
As the title suggests this allows for markdown in completion and hover documentation.

![hover](https://user-images.githubusercontent.com/623137/37648154-758b7efa-2c2e-11e8-934f-53989ba1159b.png)

![definition](https://user-images.githubusercontent.com/623137/37648155-7704203e-2c2e-11e8-91a2-e05687ae1586.png)
