### PR TITLE
Correctly fetch script document for Go-to-Definition

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -300,14 +300,14 @@ export function getJavascriptMode(
       }
 
       const definitionResults: Definition = [];
-      const program = service.getProgram();
       definitions.forEach(d => {
-        const sourceFile = program.getSourceFile(d.fileName)!;
-        const definitionTargetDoc = TextDocument.create(d.fileName, 'vue', 0, sourceFile.getFullText());
-        definitionResults.push({
-          uri: Uri.file(d.fileName).toString(),
-          range: convertRange(definitionTargetDoc, d.textSpan)
-        });
+        const definitionTargetDoc = getScriptDocByFsPath(fileFsPath);
+        if (definitionTargetDoc) {
+          definitionResults.push({
+            uri: Uri.file(d.fileName).toString(),
+            range: convertRange(definitionTargetDoc, d.textSpan)
+          });
+        }
       });
       return definitionResults;
     },


### PR DESCRIPTION
This is more consistent with find-all-references which uses the same function.

Fixes #741