### PR TITLE
[Discussion] [Live Share] Restrict language client to file schemes

### DIFF
--- a/client/vueMain.ts
+++ b/client/vueMain.ts
@@ -68,7 +68,10 @@ export function activate(context: ExtensionContext) {
     debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
   };
 
-  const documentSelector = ['vue'];
+  const documentSelector = [
+    { language: 'vue', scheme: 'file' },
+    { language: 'vue', scheme: 'untitled' }
+  ];
   const config = workspace.getConfiguration();
 
   const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Vue.js files, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Vetur extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Vue.js project using Live Share, and doesn't have the Vetur extension installed, they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Vetur extension installed. Additionally, this wouldn't impact the "local" Vue.js development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*