### PR TITLE
fix javascript's format for non-standard vue

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -350,7 +350,7 @@ export function getJavascriptMode(
       const needIndent = config.vetur.format.scriptInitialIndent;
       const parser = scriptDoc.languageId === 'javascript' ? 'babylon' : 'typescript';
       if (defaultFormatter === 'prettier') {
-        const code = scriptDoc.getText();
+        const code = doc.getText(range);
         const filePath = getFileFsPath(scriptDoc.uri);
         if (config.prettier.eslintIntegration) {
           return prettierEslintify(code, filePath, range, needIndent, formatParams, config.prettier, parser);


### PR DESCRIPTION
Recently I write my own module system in vue's form to take advantage of vue's tools. And I found that format my non-standard vue code with vetur may cause error.

If I format the following code with vetur, the first script tag's content will cover the second script tag's content.

So I wrote a fix for this. Sorry for bothering.

```vue
<script id='action'>
/// <reference path="../../../typings/mi-home-lib.d.ts" />
import {
    Rag
} from "mi-home-lib";

module.exports = class extends Rag{
    constructor(...args) {
        super(...args);
        // use this.$dom,this.props,this.$$
    }
}
</script>

<script id='export'>   
registerAction(async ($dom, props) => {

});
</script>

<script lang='json5' id='form'>     
{
    independent: true,
    chinese:"{{chinese}}",
    kind : "{{kind}}",
    preview:"{{preview}}"
    schema: {
        content: {
            type: "string",
            title: "内容",
        },       
    },
}
</script>

<style lang='less' scoped>    
&{

}
</style>

<template id='model'>
    <div ng-bind="rag.content"></div>
</template>

```


