### PR TITLE
Add vuepress support for documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,0 +1,31 @@
+module.exports = {
+    title: 'Vetur',
+    description: "Vue tooling for VS Code.",
+    themeConfig: {
+      repo: 'vuejs/vetur',
+      editLinks: true,
+      docsDir: 'docs',
+      sidebar: [
+        '/setup',
+        {
+            title: 'Features',
+            collapsable: false,
+            children: [
+                '/highlighting',
+                '/snippet',
+                '/emmet',
+                '/linting-error',
+                '/formatting',
+                '/intellisense',
+                '/debugging',
+                '/framework'
+            ]
+        },
+        '/FAQ',
+        '/CONTRIBUTING',
+        '/roadmap',
+        '/CHANGELOG',
+        '/credits'
+    ]
+    }
+  }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,7 +49,7 @@
 - Docs for generating grammar for custom blocks: https://vuejs.github.io/vetur/highlighting.html.
 - Allow `php` as one of the custom block language. #536.
 - Disallow longer version of `lang` in custom block setting (`js` over `javascript`, `md` over `markdown`).
-- Pretty print generated gramamr so it's readable. (You can find it at ~/.vscode/extensions/octref.vetur-<version>./syntaxes/vue-generated.json).
+- Pretty print generated gramamr so it's readable. (You can find it at `~/.vscode/extensions/octref.vetur-<version>./syntaxes/vue-generated.json`).
 
 ### 0.11.1 | 2017-11-10
 
@@ -261,7 +261,7 @@ Shoutout to @HerringtonDarkholme who helped implementing many new features!
 
 ### 0.6.9 | 2017-05-14
 
-- Update grammar to allow tags like <template-component> in vue-html. #189.
+- Update grammar to allow tags like `<template-component>` in vue-html. #189.
 - Update grammar to allow html comments outside all regions. #195.
 - Handle new file creation so vetur's IntelliSense work on it. #192.
 - Enable breakpoints for vue files. Doc for debugging coming later in #201.


### PR DESCRIPTION
This pull request allows documentation to build using vuepress instead of gitbooks, which allows using the advantages of vuepress. 

This configuration file allows the static build to link to the github pages for contribution, as well as configuring the sidebar.