### PR TITLE
fix: prettier-eslint no inferred parser error (fix #835)

### DIFF
--- a/server/src/utils/prettier/index.ts
+++ b/server/src/utils/prettier/index.ts
@@ -40,7 +40,9 @@ export function prettierEslintify(
     const prettierOptions = getPrettierOptions(prettierVSCodeConfig, parser, filePath);
 
     const prettierifiedCode = prettierEslint({
-      filePath: require('path').dirname(filePath),
+      // filePath will lead to Error: No parser could be inferred for file
+      // maybe pass the vue file's content as text and the corresponding filePath?
+      // filePath: require('path').dirname(filePath),
       text: code,
       fallbackPrettierOptions: prettierOptions
     });


### PR DESCRIPTION
# Code Review

(You can use the link to view the code)
(Code snippet are also pasted below)

- [Currently](https://github.com/vuejs/vetur/blob/master/server/src/utils/prettier/index.ts#L43), `vetur` pass the folder of code as the `filePath`.
- [And](https://github.com/prettier/prettier/blob/cdcb7b11c9afc850ab24420407144772983eefee/src/main/options.js#L44) so `prettier` is going to use that `filePath` to infer a proper parser.
- Since the `filePath` is actually a folder. [The](https://github.com/prettier/prettier/blob/65d595d60aa6b7d5e8798c2a5fca962f2305c196/src/main/options.js#L115) `extension` will be `''`.
- [And `prettier`](https://github.com/prettier/prettier/blob/65d595d60aa6b7d5e8798c2a5fca962f2305c196/src/main/options.js#L123) won't able to infer a proper parser from an empty extension.
- [So](https://github.com/prettier/prettier/blob/65d595d60aa6b7d5e8798c2a5fca962f2305c196/src/main/options.js#L45) `prettier` will throw an error `No parser could be inferred for file`.

```js
    const prettierifiedCode = prettierEslint({
      filePath: require('path').dirname(filePath),
      text: code,
      fallbackPrettierOptions: prettierOptions
    });
```

```js
  if (!rawOptions.parser) {
    if (!rawOptions.filepath) {
      const logger = opts.logger || console;
      logger.warn(
        "No parser and no filepath given, using 'babylon' the parser now " +
          "but this will throw an error in the future. " +
          "Please specify a parser or a filepath so one can be inferred."
      );
      rawOptions.parser = "babylon";
    } else {
      rawOptions.parser = inferParser(rawOptions.filepath, rawOptions.plugins);
      if (!rawOptions.parser) {
        throw new UndefinedParserError(
          `No parser could be inferred for file: ${rawOptions.filepath}`
        );
      }
    }
  }
```

```js
function inferParser(filepath, plugins) {
  const filepathParts = normalizePath(filepath).split("/");
  const filename = filepathParts[filepathParts.length - 1].toLowerCase();

  const language = getSupportInfo(null, {
    plugins
  }).languages.find(
    language =>
      language.since !== null &&
      ((language.extensions &&
        language.extensions.some(extension => filename.endsWith(extension))) ||
        (language.filenames &&
          language.filenames.find(name => name.toLowerCase() === filename)))
  );

  return language && language.parsers[0];
}
```

# Quick fix

- Don't pass `filePath` [and](https://github.com/prettier/prettier/blob/65d595d60aa6b7d5e8798c2a5fca962f2305c196/src/main/options.js#L41) `prettier` will use the default parser `babylon `.

# PS

According to `prettier`'s [code](https://github.com/prettier/prettier/blob/65d595d60aa6b7d5e8798c2a5fca962f2305c196/src/main/options.js#L33)

```
        "No parser and no filepath given, using 'babylon' the parser now " +
          "but this will throw an error in the future. " +
          "Please specify a parser or a filepath so one can be inferred."
```

So this is just a temporary fix. Since `prettier-eslint` can handle `.vue` files, I think a more resonable fix would be

- pass the vue file's content as text and the corresponding filePath

But this will require a lot of reconstruction and also I don't know if the performance is OK. So I just go with the quick fix.