### PR TITLE
Upgraded Stylus Supremacy to version 2.12.6

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
     "read-pkg-up": "^4.0.0",
     "resolve": "^1.8.1",
     "stylus": "^0.54.5",
-    "stylus-supremacy": "~2.12.0",
+    "stylus-supremacy": "^2.12.6",
     "typescript": "^3.0.3",
     "vscode-css-languageservice": "^3.0.3",
     "vscode-emmet-helper": "^1.1.19",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3102,9 +3102,9 @@ stylint@^1.5.9:
     user-home "2.0.0"
     yargs "4.7.1"
 
-stylus-supremacy@~2.12.0:
-  version "2.12.5"
-  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.12.5.tgz#9baa77da6908ece01ee589aebbc4d3bb9a385c11"
+stylus-supremacy@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.12.6.tgz#d9b12369aec8d9cb4d5789b7b1d6045df45a30ab"
   dependencies:
     glob "^7.1.3"
     js-yaml "^3.12.0"


### PR DESCRIPTION
Upgrading Stylus Supremacy to v2.12.6 fixes https://github.com/vuejs/vetur/issues/918 by https://github.com/ThisIsManta/stylus-supremacy/commit/7f84e522e8d419ef63003bc9907408e72e1845ca