### PR TITLE
Settings for vscode, prettier, prettier-eslint integration

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -98,3 +98,36 @@ Other settings are read from `stylusSupremacy.*`. You can install [Stylus Suprem
   "stylusSupremacy.insertSemicolons": false
 }
 ```
+
+#### Example config for Visual Studio Code, prettier, prettier-eslint integration
+
+If you use prettier and prettier-eslint integration in Visual Studio Code, to enable formatting on `template`, `script` and `style` sections of vue files, you may use user settings below. Descriptions are provided in comments.
+
+```js
+{
+  "prettier.eslintIntegration": true,
+  "eslint.autoFixOnSave": true,
+  
+  "[vue]": {
+    "editor.formatOnSave": true
+  },
+
+  // Enable formatter for <template> in vue files, which is disabled by default in vetur.
+  "vetur.format.defaultFormatter.html": "prettyhtml",
+
+  // To enable vue in prettier, which is disabled by default. See: https://github.com/prettier/prettier-vscode#prettierdisablelanguages-default-vue
+  "prettier.disableLanguages": [],
+  
+  // Enable vue in eslint
+  "eslint.options": { "extensions": [".html", ".js", ".vue", ".jsx"] },
+  
+  // Enable autofix of vue in eslint
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    {
+      "language": "vue",
+      "autoFix": true
+    }
+}
+```


### PR DESCRIPTION
There are lots of questions in issues part of vetur and vscode-prettier how to format `template`, `script` and `style` sections of vue files at the same times. Providing example setting in doc greatly helps in those cases.

Original suggestion belongs to @Bartozzz, see: https://github.com/vuejs/vetur/issues/695#issuecomment-428654748