### PR TITLE
Don't include .ts and .map files in vscode extension bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,10 +5,10 @@ build/
 docs/
 client/
 **/test/
+server/src/
 
 .**
 
 **/*.map
-**/*.ts
 **/tsconfig.json
 **/tslint.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,11 @@
 build/
 docs/
 client/
-test/
+**/test/
 
 .**
+
+**/*.map
+**/*.ts
+**/tsconfig.json
+**/tslint.json


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/62687

Excludes all `.map` files, most `.ts` files, supporting files like `tsconfig.json`, and all tests from the vscode vsix. These files should not be needed in the extension bundle.

Before:

```
vsce package
vetur-0.13.0.vsix (16291 files, 29.33MB)
```

After:

```
vsce-package
vetur-0.13.0.vsix (14499 files, 26.78MB)
```
