### PR TITLE
Update js-beautify-html default settings to match Vue style guide

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -69,9 +69,9 @@ VS Code's js/ts formatter built on TypeScript language service.
 
 Other settings are read from `javascript.format.*` and `typescript.format.*`.
 
-#### js-beautify-html [deprecated]
+#### js-beautify-html
 
-Alternative html formatter. Deprecated and turned off by default. Use at your own risk.
+Alternative html formatter.
 
 `tabSize` and `insertSpaces` are read from `editor.tabSize` and `editor.insertSpaces`.
 

--- a/package.json
+++ b/package.json
@@ -305,7 +305,9 @@
             }
           },
           "default": {
-            "js-beautify-html": {},
+            "js-beautify-html": {
+              "wrap_attributes": "force-expand-multiline"
+            },
             "prettyhtml": {
               "printWidth": 100,
               "singleQuote": false

--- a/server/src/modes/template/services/htmlFormat.ts
+++ b/server/src/modes/template/services/htmlFormat.ts
@@ -87,6 +87,6 @@ const defaultHtmlOptions: HTMLBeautifyOptions = {
   preserve_newlines: true, // Whether existing line breaks before elements should be preserved
   unformatted: [], // Tags that shouldn't be formatted. Causes mis-alignment
   wrap_line_length: 0, // Lines should wrap at next opportunity after this number of characters (0 disables)
-  wrap_attributes: 'auto' as any
+  wrap_attributes: 'force-expand-multiline' as any
   // Wrap attributes to new lines [auto|force|force-aligned|force-expand-multiline] ["auto"]
 };


### PR DESCRIPTION
js-beautify-html has had many fixes and is a bit more active. They've fixed the force-expand-multiline formatting, which was the biggest issue, in my opinion, that made it very broken. I updated the docs to reflect this. I think it is fair to let people know it is a viable option, considering it's popularity and size.

I also set the default settings to match the [Vue style guide](https://vuejs.org/v2/style-guide/).

I changed `auto` to `force-expand-multiline` because `auto` never seemed to trigger multiline expansion and the style guide states anything more than one attribute should be expanded. Of course, this can be overridden by the config.