### PR TITLE
.prettierrc configuration was not hyperlinked

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -37,7 +37,7 @@ Current default:
 
 Settings precedence:
 
-1. `.prettierrc` at project root. See format at https://prettier.io/docs/en/configuration.html
+1. `.prettierrc` at project root. See format at [https://prettier.io/docs/en/configuration.html](https://prettier.io/docs/en/configuration.html)
 2. `prettier.*`. You can install [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to get IntelliSense for settings, but Vetur will work without it.
 
 ESLint integration: `"prettier.eslintIntegration": true`. Settings are read from `.eslintrc`.


### PR DESCRIPTION
When viewing the docs at https://vuejs.github.io/vetur/formatting.htm the link to `.prettierrc` configuration was not hyperlinked.