### PR TITLE
Rework formatter

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -11,11 +11,14 @@ Vetur has support for formatting embedded `html/css/scss/less/postcss/stylus/js/
 These formatters are available:
 
 - [`prettier`](https://github.com/prettier/prettier): For css/scss/less/js/ts.
+- [`prettier-eslint`](https://github.com/prettier/prettier-eslint): For js. Run `prettier` and `eslint --fix`.
 - [`prettyhtml`](https://github.com/Prettyhtml/prettyhtml): For html.
 - [`stylus-supremacy`](https://github.com/ThisIsManta/stylus-supremacy): For stylus.
 - [`vscode-typescript`](https://github.com/Microsoft/TypeScript): For js/ts. The same js/ts formatter for VS Code.
 
-Choose each language's default formatter in VS Code config, `vetur.format.defaultFormatter`.
+Vetur bundles all the above formatters. When Vetur observes a local install of the formattesr, it'll prefer to use the local version.
+
+You can choose each language's default formatter in VS Code config, `vetur.format.defaultFormatter`.
 **Setting a language's formatter to `none` disables formatter for that language.**
 
 Current default:
@@ -33,20 +36,35 @@ Current default:
 }
 ```
 
+## Settings
+
+These two settings are inherited by all formatters:
+
+```json
+{
+  "vetur.format.options.tabSize": 2,
+  "vetur.format.options.useTabs": false
+}
+```
+
+However, when a local config (such as `.prettierrc`) is found, Vetur will prefer it. For example:
+
+- `.prettierrc` is present but does not set `tabWidth` explicitly: Vetur uses `vetur.format.options.tabSize` as the `tabWidth` for prettier.
+- `.prettierrc` is present and sets `tabWidth` explicitly: Vetur ignores `vetur.format.options.tabSize`, always using the value in `.prettierrc`.
+
+`useTabs` works the same way.
+
 #### [prettier](https://prettier.io/)
 
-Settings precedence:
+Opinionated formatter. Settings are read from `.prettierrc` at project root. See format at [https://prettier.io/docs/en/configuration.html](https://prettier.io/docs/en/configuration.html).
 
-1. `.prettierrc` at project root. See format at [https://prettier.io/docs/en/configuration.html](https://prettier.io/docs/en/configuration.html)
-2. `prettier.*`. You can install [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to get IntelliSense for settings, but Vetur will work without it.
+#### [prettier-eslint](https://github.com/prettier/prettier-eslint)
 
-ESLint integration: `"prettier.eslintIntegration": true`. Settings are read from `.eslintrc`.
+Prettier + `eslint --fix`. Settings are read from `.prettierrc` and `.eslintrc` at project root.
 
 #### [prettyhtml](https://github.com/Prettyhtml/prettyhtml)
 
 The default formatter for Vue templates.
-
-`tabWidth` and `useTabs` are read from `editor.tabSize` and `editor.insertSpaces`.
 
 Other settings include:
 
@@ -59,19 +77,17 @@ Other settings include:
 }
 ```
 
-#### vscode-typescript
+`prettier` options are read from local `.prettierrc` config.
 
-VS Code's js/ts formatter built on TypeScript language service.
+#### [vscode-typescript](https://github.com/microsoft/typescript)
 
-`tabSize` and `insertSpaces` are read from `editor.tabSize` and `editor.insertSpaces`.
+VS Code's js/ts formatter built on [TypeScript](https://github.com/microsoft/typescript) language service.
 
-Other settings are read from `javascript.format.*` and `typescript.format.*`.
+Settings are read from `javascript.format.*` and `typescript.format.*`.
 
-#### js-beautify-html
+#### [js-beautify-html](https://github.com/beautify-web/js-beautify)
 
 Alternative html formatter.
-
-`tabSize` and `insertSpaces` are read from `editor.tabSize` and `editor.insertSpaces`.
 
 Default settings are [here](https://github.com/vuejs/vetur/blob/master/server/src/modes/template/services/htmlFormat.ts). You can override them by setting `vetur.format.defaultFormatterOptions.js-beautify-html`.
 
@@ -83,9 +99,7 @@ Default settings are [here](https://github.com/vuejs/vetur/blob/master/server/sr
 }
 ```
 
-#### stylus-supremacy
-
-`tabSize` and `insertSpaces` are read from `editor.tabSize` and `editor.insertSpaces`.
+#### [stylus-supremacy](https://thisismanta.github.io/stylus-supremacy/)
 
 Other settings are read from `stylusSupremacy.*`. You can install [Stylus Supremacy extension](https://marketplace.visualstudio.com/items?itemName=thisismanta.stylus-supremacy) to get IntelliSense for settings, but Vetur will work without it. A useful default:
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,16 @@
           "default": true,
           "description": "Validate js/ts in <script>"
         },
+        "vetur.format.options.tabSize": {
+          "type": "number",
+          "default": 2,
+          "description": "Number of spaces per indentation level. Inherited by all formatters."
+        },
+        "vetur.format.options.useTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use tabs for indentation. Inherited by all formatters."
+        },
         "vetur.format.defaultFormatter.html": {
           "type": "string",
           "default": "prettyhtml",
@@ -251,11 +261,13 @@
           "enum": [
             "none",
             "prettier",
+            "prettier-eslint",
             "vscode-typescript"
           ],
           "enumDescriptions": [
             "disable formatting",
             "js formatter from prettier",
+            "prettier-eslint",
             "js formatter from TypeScript"
           ],
           "description": "Default formatter for <script> region"

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,14 @@
+export interface VLSFormatConfig {
+  defaultFormatter: {
+    [lang: string]: string;
+  };
+  defaultFormatterOptions: {
+    [lang: string]: any;
+  };
+  scriptInitialIndent: boolean;
+  styleInitialIndent: boolean;
+  options: {
+    tabSize: number;
+    useTabs: boolean;
+  };
+}

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -34,6 +34,7 @@ import * as ts from 'typescript';
 import * as _ from 'lodash';
 
 import { nullMode, NULL_SIGNATURE } from '../nullMode';
+import { VLSFormatConfig } from '../../config';
 
 // Todo: After upgrading to LS server 4.0, use CompletionContext for filtering trigger chars
 // https://microsoft.github.io/language-server-protocol/specification#completion-request-leftwards_arrow_with_hook
@@ -356,21 +357,27 @@ export function getJavascriptMode(
         return [];
       }
 
-      const needIndent = config.vetur.format.scriptInitialIndent;
       const parser = scriptDoc.languageId === 'javascript' ? 'babylon' : 'typescript';
-      if (defaultFormatter === 'prettier') {
+      const needInitialIndent = config.vetur.format.scriptInitialIndent;
+      const vlsFormatConfig: VLSFormatConfig = config.vetur.format;
+
+      if (defaultFormatter === 'prettier' || defaultFormatter === 'prettier-eslint') {
         const code = scriptDoc.getText();
         const filePath = getFileFsPath(scriptDoc.uri);
-        if (config.prettier.eslintIntegration) {
-          return prettierEslintify(code, filePath, range, needIndent, formatParams, config.prettier, parser);
-        } else {
-          return prettierify(code, filePath, range, needIndent, formatParams, config.prettier, parser);
-        }
-      } else {
-        const initialIndentLevel = needIndent ? 1 : 0;
+
+        return defaultFormatter === 'prettier'
+          ? prettierify(code, filePath, range, vlsFormatConfig, parser, needInitialIndent)
+          : prettierEslintify(code, filePath, range, vlsFormatConfig, parser, needInitialIndent);
+      }
+      
+      else {
+        const initialIndentLevel = needInitialIndent ? 1 : 0;
         const formatSettings: ts.FormatCodeSettings =
           scriptDoc.languageId === 'javascript' ? config.javascript.format : config.typescript.format;
-        const convertedFormatSettings = convertOptions(formatSettings, formatParams, initialIndentLevel);
+        const convertedFormatSettings = convertOptions(formatSettings, {
+          tabSize: vlsFormatConfig.options.tabSize,
+          insertSpaces: !vlsFormatConfig.options.useTabs
+        }, initialIndentLevel);
 
         const fileFsPath = getFileFsPath(doc.uri);
         const start = scriptDoc.offsetAt(range.start);

--- a/server/src/modes/style/index.ts
+++ b/server/src/modes/style/index.ts
@@ -16,6 +16,7 @@ import { getFileFsPath } from '../../utils/paths';
 import { prettierify } from '../../utils/prettier';
 import { ParserOption } from '../../utils/prettier/prettier.d';
 import { NULL_HOVER } from '../nullMode';
+import { VLSFormatConfig } from '../../config';
 
 export function getCSSMode(documentRegions: LanguageModelCache<VueDocumentRegions>): LanguageMode {
   const languageService = getCSSLanguageService();
@@ -67,12 +68,14 @@ function getStyleMode(
       const embedded = embeddedDocuments.get(document);
       const emmetSyntax = languageId === 'postcss' ? 'css' : languageId;
       const lsCompletions = languageService.doComplete(embedded, position, stylesheets.get(embedded));
-      const lsItems = lsCompletions ? _.map(lsCompletions.items, i => {
-        return {
-          ...i,
-          sortText: Priority.Platform + i.label
-        };
-      }) : [];
+      const lsItems = lsCompletions
+        ? _.map(lsCompletions.items, i => {
+            return {
+              ...i,
+              sortText: Priority.Platform + i.label
+            };
+          })
+        : [];
 
       const emmetCompletions = emmet.doComplete(document, position, emmetSyntax, config.emmet);
       if (!emmetCompletions) {
@@ -135,10 +138,9 @@ function getStyleMode(
         value,
         getFileFsPath(document.uri),
         range,
-        needIndent,
-        formattingOptions,
-        config.prettier,
-        parserMap[languageId]
+        config.vetur.format as VLSFormatConfig,
+        parserMap[languageId],
+        needIndent
       );
     },
     onDocumentRemoved(document) {

--- a/server/src/modes/style/stylus/index.ts
+++ b/server/src/modes/style/stylus/index.ts
@@ -13,6 +13,7 @@ import { provideDocumentSymbols } from './symbols-finder';
 import { stylusHover } from './stylus-hover';
 import { requireLocalPkg } from '../../../utils/prettier/requirePkg';
 import { getFileFsPath } from '../../../utils/paths';
+import { VLSFormatConfig } from '../../../config';
 
 export function getStylusMode(documentRegions: LanguageModelCache<VueDocumentRegions>): LanguageMode {
   const embeddedDocuments = getLanguageModelCache(10, 60, document =>
@@ -73,7 +74,8 @@ export function getStylusMode(documentRegions: LanguageModelCache<VueDocumentReg
       const embedded = embeddedDocuments.get(document);
       const inputText = embedded.getText();
 
-      const tabStopChar = formatParams.insertSpaces ? ' '.repeat(formatParams.tabSize) : '\t';
+      const vlsFormatConfig = config.vetur.format as VLSFormatConfig;
+      const tabStopChar = vlsFormatConfig.options.useTabs ? '\t' : ' '.repeat(vlsFormatConfig.options.tabSize);
 
       // Note that this would have been `document.eol` ideally
       const newLineChar = inputText.includes('\r\n') ? '\r\n' : '\n';

--- a/server/src/modes/template/index.ts
+++ b/server/src/modes/template/index.ts
@@ -18,6 +18,7 @@ import { getTagProviderSettings } from './tagProviders';
 import { ScriptMode } from '../script/javascript';
 import { getComponentTags, getEnabledTagProviders } from './tagProviders';
 import { DocumentContext } from '../../types';
+import { VLSFormatConfig } from '../../config';
 
 type DocumentRegionCache = LanguageModelCache<VueDocumentRegions>;
 
@@ -70,7 +71,7 @@ export function getVueHTMLMode(
       return findDocumentSymbols(document, vueDocuments.get(document));
     },
     format(document: TextDocument, range: Range, formattingOptions: FormattingOptions) {
-      return htmlFormat(document, range, formattingOptions, config);
+      return htmlFormat(document, range, config.vetur.format as VLSFormatConfig);
     },
     findDefinition(document: TextDocument, position: Position) {
       const embedded = embeddedDocuments.get(document);

--- a/server/src/utils/prettier/prettier.d.ts
+++ b/server/src/utils/prettier/prettier.d.ts
@@ -1,5 +1,5 @@
 export type ParserOption = 'babylon' | 'flow' | 'css' | 'scss' | 'less' | 'typescript' | 'json' | 'graphql';
-type TrailingCommaOption = 'none' | 'es5' | 'all' | boolean; /* deprecated boolean*/
+type TrailingCommaOption = 'none' | 'es5' | 'all';
 
 /**
  * Prettier configuration
@@ -14,63 +14,21 @@ export interface PrettierConfig {
   parser: ParserOption;
   semi: boolean;
   useTabs: boolean;
+  proseWrap: 'preserve' | 'always' | 'never';
   arrowParens: 'avoid' | 'always';
-}
-/**
- * prettier-vscode specific configuration
- */
-interface ExtensionConfig {
-  /**
-   * Use 'prettier-eslint' instead of 'prettier'.
-   * Other settings will only be fallbacks in case they could not be inferred from eslint rules.
-   */
-  eslintIntegration: boolean;
-  /**
-   * Use 'prettier-stylelint' instead of 'prettier'.
-   * Other settings will only be fallbacks in case they could not be inferred from eslint rules.
-   */
-  stylelintIntegration: boolean;
-  /**
-   * Path to '.prettierignore' or similar.
-   */
-  ignorePath: string;
-  /**
-   * Language ids to run javascript prettier on.
-   */
-  javascriptEnable: ('javascript' | 'javascriptreact' | string)[];
-  /**
-   * Language ids to run typescript prettier on.
-   */
-  typescriptEnable: ('typescript' | 'typescriptreact' | string)[];
-  /**
-   * Language ids to run postcss prettier on.
-   */
-  cssEnable: ('css' | 'less' | 'scss' | string)[];
-  /**
-   * Language ids to run json prettier on
-   */
-  jsonEnable: ('json' | string)[];
-  /**
-   * Language ids to run graphql prettier on
-   */
-  graphqlEnable: ('graphql' | string)[];
+  rangeStart: number;
+  rangeEnd: number;
+  filepath: string;
+  jsxSingleQuote: boolean;
+  htmlWhitespaceSensitivity: 'css' | 'strict' | 'ignore';
+  endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
 }
 
-/**
- * Configuration for prettier-vscode
- */
-export type PrettierVSCodeConfig = ExtensionConfig & PrettierConfig;
 export interface Prettier {
   format(text: string, options?: Partial<PrettierConfig>): string;
-  resolveConfig(
-    filePath: string,
-    options?: {
-      /**
-       * Use cache, defaults to true.
-       */
-      useCache: boolean;
-    }
-  ): Promise<PrettierConfig>;
+  resolveConfig: {
+    sync(filePath: string, options?: { useCache: boolean }): PrettierConfig;
+  };
   clearConfigCache(): void;
   readonly version: string;
 }
@@ -127,13 +85,3 @@ interface PrettierEslintOptions {
  * @returns {string} the formatted code.
  */
 export type PrettierEslintFormat = (options: PrettierEslintOptions) => string;
-
-export interface PrettierStylelint {
-  format(options: PrettierEslintOptions): Promise<string>;
-  resolveConfig(
-    file: string,
-    options?: {
-      useCache: boolean;
-    }
-  ): Promise<[PrettierConfig, Object]>;
-}

--- a/server/src/utils/strings.ts
+++ b/server/src/utils/strings.ts
@@ -1,4 +1,4 @@
-import { FormattingOptions } from 'vscode-languageserver-types';
+import { VLSFormatConfig } from '../config';
 
 export function getWordAtText(text: string, offset: number, wordDefinition: RegExp): { start: number; length: number } {
   let lineStart = offset;
@@ -38,14 +38,14 @@ const nonEmptyLineRE = /^(?!$)/gm;
  *  wrap text in section tags like <template>, <style>
  *  add leading and trailing newline and optional indentation
  */
-export function indentSection(text: string, options: FormattingOptions): string {
+export function indentSection(text: string, options: VLSFormatConfig): string {
   const initialIndent = generateIndent(options);
   return text.replace(nonEmptyLineRE, initialIndent);
 }
 
-function generateIndent(options: FormattingOptions) {
-  if (options.insertSpaces) {
-    return ' '.repeat(options.tabSize);
+function generateIndent(options: VLSFormatConfig) {
+  if (!options.options.useTabs) {
+    return ' '.repeat(options.options.tabSize);
   } else {
     return '\t';
   }


### PR DESCRIPTION
- [x] Add `prettier-eslint` as one of the option for `js` formatter
- [x] Add `vetur.format.options.[tabSize|useTabs]`, and no longer depend on VS Code's auto indent detection
- [x] Start writing a VLSConfig, part of #977 

FYI @ThisIsManta @Coder-256 @StarpTech 