### PR TITLE
Tell to install Vue manually for Intellisense (Nuxt)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -93,3 +93,7 @@ index.vue
 import a from 'components/a.vue'
 import b from 'components/b.vue'
 ```
+
+### Using Nuxt?
+
+Don't forget to install Vue (and probably Vuex / Vue-router) manually, as Nuxt does not come with it by default, to make sure you can use all of Vetur's features, such as auto-complete / Intellisense.


### PR DESCRIPTION
Visual Studio Code's recent Vue.js tutorial made me notice that I didn't benefit from Vetur's auto-completion in `.vue` files, and I figured Vue wasn't installed by Nuxt by default, which I'm using. Might as well tell users here?