### PR TITLE
fix mutiple stylus format bug

### DIFF
--- a/server/src/modes/style/index.ts
+++ b/server/src/modes/style/index.ts
@@ -154,7 +154,7 @@ function getStyleMode(
   };
 }
 
-function getValueAndRange(document: TextDocument, currRange: Range): { value: string; range: Range } {
+export function getValueAndRange(document: TextDocument, currRange: Range): { value: string; range: Range } {
   let value = document.getText();
   let range = currRange;
 

--- a/server/src/modes/style/stylus/stylus-supremacy.d.ts
+++ b/server/src/modes/style/stylus/stylus-supremacy.d.ts
@@ -1,6 +1,10 @@
 import { FormattingOptions } from 'stylus-supremacy';
-
+import * as vscode from 'vscode';
+import { Range } from 'vscode-languageserver-types';
 export interface IStylusSupremacy {
   createFormattingOptions(options: any): FormattingOptions;
-  format(content: string, options: FormattingOptions): string;
+  format(content: string, 
+    options: FormattingOptions, 
+    cancellationToken: vscode.CancellationToken | null, 
+    originalRange: Range): string;
 }


### PR DESCRIPTION
Issues: https://github.com/vuejs/vetur/issues/499

```js
function getEmbeddedDocument(document: TextDocument, contents: EmbeddedRegion[], languageId: string): TextDocument {
  const oldContent = document.getText();
  let result = '';
  // main problem point
  // mutiple same languageId will be break
  for (const c of contents) {
    if (c.languageId === languageId) {
      result = oldContent.substring(0, c.start).replace(/./g, ' ');
      result += oldContent.substring(c.start, c.end);
      break;
    }
  }
  return TextDocument.create(document.uri, languageId, document.version, result);
}
```

I use `getValueAndRange` function to reslove correct inputValue.and `format` function in vscode-stylus-supremacy` has multiple arguments. It will be return right formatted text.

![origin-before](https://user-images.githubusercontent.com/7511329/50411449-087ccc80-083b-11e9-8a91-fc5492ecc595.png)

![origin-after](https://user-images.githubusercontent.com/7511329/50411448-087ccc80-083b-11e9-88fc-c372cb807b0a.png)

![fixed-after](https://user-images.githubusercontent.com/7511329/50411447-087ccc80-083b-11e9-8e4e-77e502888948.png)