### PR TITLE
Highlight vue-specific attributes without values

### DIFF
--- a/syntaxes/vue-generated.json
+++ b/syntaxes/vue-generated.json
@@ -112,7 +112,7 @@
           "name": "punctuation.separator.key-value.html"
         }
       },
-      "begin": "(?:\\b(v-)|(:|@))([a-zA-Z\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z\\-_]+))*\\s*(=)",
+      "begin": "(?:\\b(v-)|(:|@))([a-zA-Z\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z\\-_]+))*\\s*(=)?",
       "end": "(?<='|\")",
       "name": "meta.directive.vue",
       "patterns": [

--- a/syntaxes/vue-html.YAML
+++ b/syntaxes/vue-html.YAML
@@ -171,7 +171,7 @@ repository:
 
   vue-directives:
     name: meta.directive.vue
-    begin: ((?:\b(v-)|(:|@))([a-zA-Z0-9\-_]+)(?:\:([a-zA-Z0-9\-_]+))?(?:\.([a-zA-Z0-9\-_]+))*)\s*(=)
+    begin: ((?:\b(v-)|(:|@))([a-zA-Z0-9\-_]+)(?:\:([a-zA-Z0-9\-_]+))?(?:\.([a-zA-Z0-9\-_]+))*)\s*(=)?
     end: (?<='|")|(?=[\s<>`])
     captures:
       '1': {name: entity.other.attribute-name.html}

--- a/syntaxes/vue-html.json
+++ b/syntaxes/vue-html.json
@@ -104,7 +104,7 @@
                     "name": "punctuation.separator.key-value.html"
                 }
             }, 
-            "begin": "((?:\\b(v-)|(:|@))([a-zA-Z0-9\\-_]+)(?:\\:([a-zA-Z0-9\\-_]+))?(?:\\.([a-zA-Z0-9\\-_]+))*)\\s*(=)", 
+            "begin": "((?:\\b(v-)|(:|@))([a-zA-Z0-9\\-_]+)(?:\\:([a-zA-Z0-9\\-_]+))?(?:\\.([a-zA-Z0-9\\-_]+))*)\\s*(=)?", 
             "end": "(?<='|\")|(?=[\\s<>`])", 
             "name": "meta.directive.vue", 
             "patterns": [

--- a/syntaxes/vue.json
+++ b/syntaxes/vue.json
@@ -112,7 +112,7 @@
                     "name": "entity.other.attribute-name.html"
                 }
             }, 
-            "begin": "(?:\\b(v-)|(:|@))([a-zA-Z\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z\\-_]+))*\\s*(=)", 
+            "begin": "(?:\\b(v-)|(:|@))([a-zA-Z\\-_]+)(?:\\:([a-zA-Z\\-_]+))?(?:\\.([a-zA-Z\\-_]+))*\\s*(=)?", 
             "end": "(?<='|\")", 
             "name": "meta.directive.vue", 
             "patterns": [

--- a/syntaxes/vue.yaml
+++ b/syntaxes/vue.yaml
@@ -404,7 +404,7 @@ repository:
 
   vue-directives:
     name: meta.directive.vue
-    begin: (?:\b(v-)|(:|@))([a-zA-Z\-_]+)(?:\:([a-zA-Z\-_]+))?(?:\.([a-zA-Z\-_]+))*\s*(=)
+    begin: (?:\b(v-)|(:|@))([a-zA-Z\-_]+)(?:\:([a-zA-Z\-_]+))?(?:\.([a-zA-Z\-_]+))*\s*(=)?
     end: (?<='|")
     captures:
       '1': {name: entity.other.attribute-name.html}


### PR DESCRIPTION
Fixes #1009

`@click.stop`
`@submit.prevent`
...

Don't know how to build this thing... Sublime Text build with PackageDev changed almost the entire `.json` file. This PR contains just files edited by hand.

Also, CONTRIBUTING page says:
> F7 to compile yaml grammar to tmLanguage files

But the files in use are `.json`, right?

Also, you are bundling extension with all `syntax` files... Does it make sense to add `syntaxes/*.yaml` to `.vscodeignore` to exclude them?

Maybe it would be a good idea to compress `.json` syntax files before publishing extension.