### PR TITLE
Allow double-hyphen in HTML comments

### DIFF
--- a/syntaxes/vue-generated.json
+++ b/syntaxes/vue-generated.json
@@ -253,14 +253,8 @@
         }
       },
       "begin": "<!--",
-      "end": "--\\s*>",
-      "name": "comment.block.html",
-      "patterns": [
-        {
-          "match": "--",
-          "name": "invalid.illegal.bad-comments-or-CDATA.html"
-        }
-      ]
+      "end": "-->",
+      "name": "comment.block.html"
     },
     {
       "beginCaptures": {

--- a/syntaxes/vue-html.YAML
+++ b/syntaxes/vue-html.YAML
@@ -36,12 +36,9 @@ patterns:
 
 - name: comment.block.html
   begin: <!--
-  end: --\s*>
+  end: -->
   captures:
     '0': {name: punctuation.definition.comment.html}
-  patterns:
-  - name: invalid.illegal.bad-comments-or-CDATA.html
-    match: --
 
 - name: meta.tag.sgml.html
   begin: <!

--- a/syntaxes/vue-html.json
+++ b/syntaxes/vue-html.json
@@ -319,14 +319,8 @@
                 }
             }, 
             "begin": "<!--", 
-            "end": "--\\s*>", 
-            "name": "comment.block.html", 
-            "patterns": [
-                {
-                    "match": "--", 
-                    "name": "invalid.illegal.bad-comments-or-CDATA.html"
-                }
-            ]
+            "end": "-->", 
+            "name": "comment.block.html"
         }, 
         {
             "captures": {

--- a/syntaxes/vue.json
+++ b/syntaxes/vue.json
@@ -253,14 +253,8 @@
                 }
             }, 
             "begin": "<!--", 
-            "end": "--\\s*>", 
-            "name": "comment.block.html", 
-            "patterns": [
-                {
-                    "match": "--", 
-                    "name": "invalid.illegal.bad-comments-or-CDATA.html"
-                }
-            ]
+            "end": "-->", 
+            "name": "comment.block.html"
         }, 
         {
             "beginCaptures": {

--- a/syntaxes/vue.yaml
+++ b/syntaxes/vue.yaml
@@ -11,12 +11,9 @@ patterns:
 
 - name: comment.block.html
   begin: <!--
-  end: --\s*>
+  end: -->
   captures:
     '0': {name: punctuation.definition.comment.html}
-  patterns:
-  - name: invalid.illegal.bad-comments-or-CDATA.html
-    match: --
 
 # template - single line
 # <template src="index.html" />


### PR DESCRIPTION
Fixes #1023. It looks like the current grammar is a hold-over from pre-HTML5 days when double-hypens weren't allowed in comments.