### PR TITLE
Add support for nuxt-ts and nuxt-ts-edge

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -25,8 +25,8 @@ Vetur reads the `package.json` **in your project root** to determine if it shoul
 | `bootstrap-vue` | [bootstrap-vue-helper-json](https://github.com/bootstrap-vue/bootstrap-vue-helper-json) |
 | `buefy` | [buefy-helper-json](https://github.com/buefy/buefy-helper-json) |
 | `vuetify` | [vuetify-helper-json](https://github.com/vuetifyjs/vuetify-helper-json) |
-| `nuxt` / `nuxt-legacy` | Bundled in [@nuxt/vue-app](https://www.npmjs.com/package/@nuxt/vue-app) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
-| `nuxt-edge` | Bundled in [@nuxt/vue-app-edge](https://www.npmjs.com/package/@nuxt/vue-app-edge) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
+| `nuxt` / `nuxt-legacy` / `nuxt-ts` | Bundled in [@nuxt/vue-app](https://www.npmjs.com/package/@nuxt/vue-app) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
+| `nuxt-edge` / `nuxt-ts-edge` | Bundled in [@nuxt/vue-app-edge](https://www.npmjs.com/package/@nuxt/vue-app-edge) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
 | `quasar-framework` | Bundled in [quasar](https://www.npmjs.com/package/quasar) package |
 
 Getting `element-ui`'s completions is as easy as running `yarn add element-ui` and reloading VS Code.

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -76,7 +76,9 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     if (
       packageJson.dependencies['nuxt'] ||
       packageJson.dependencies['nuxt-legacy'] ||
-      packageJson.dependencies['nuxt-edge']
+      packageJson.dependencies['nuxt-edge'] ||
+      packageJson.dependencies['nuxt-ts'] ||
+      packageJson.dependencies['nuxt-ts-edge']
     ) {
       const nuxtTagProvider = getNuxtTagProvider(workspacePath);
       if (nuxtTagProvider) {


### PR DESCRIPTION
With [nuxt v2.4.0](https://github.com/nuxt/nuxt.js/releases/tag/v2.4.0), `nuxt-ts` and `nuxt-ts-edge` arrived.
This pull request adds vetur support for both dependencies.