### PR TITLE
Clear diagnostics on document close

### DIFF
--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -165,6 +165,7 @@ export class VLS {
     });
     this.documentService.onDidClose(e => {
       this.removeDocument(e.document);
+      this.lspConnection.sendDiagnostics({ uri: e.document.uri, diagnostics: [] });
     });
     this.lspConnection.onDidChangeWatchedFiles(({ changes }) => {
       const jsMode = this.languageModes.getMode('javascript');


### PR DESCRIPTION
Addresses https://github.com/vuejs/vetur/issues/1181. Based on [vscode-eslint's handling](https://github.com/Microsoft/vscode-eslint/blob/ec619b2baa8e7500a451df4156f1973acce315df/server/src/eslintServer.ts#L699) of diagnostics when a document is closed.