### PR TITLE
Fix invalid diagnostic range when template block is not placed on the top of file

### DIFF
--- a/server/src/modes/script/preprocess.ts
+++ b/server/src/modes/script/preprocess.ts
@@ -38,7 +38,7 @@ function parseVueTemplate(text: string): string {
   if (rawText.replace(/\s/g, '') === '') {
     return '';
   }
-  return rawText.replace(/^\s*\n/, '<template>\n').replace(/\s*\n$/, '\n</template>');
+  return rawText.replace(/ {10}/, '<template>') + '</template>';
 }
 
 export function createUpdater(tsModule: T_TypeScript) {

--- a/test/lsp/fixture/client/templateDiagnostics/template-position.vue
+++ b/test/lsp/fixture/client/templateDiagnostics/template-position.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      message: 'Hello'
+    }
+  }
+})
+</script>
+
+<template>
+  <p>{{ message + foo }}</p>
+</template>
+

--- a/test/lsp/templateDiagnostics/basic.test.ts
+++ b/test/lsp/templateDiagnostics/basic.test.ts
@@ -96,6 +96,16 @@ describe('template-diag Should find diagnostics in <template> region', () => {
           message: "Property 'notExist' does not exist on type"
         }
       ]
+    },
+    {
+      file: 'template-position.vue',
+      diagnostics: [
+        {
+          range: sameLineRange(13, 18, 21),
+          severity: vscode.DiagnosticSeverity.Error,
+          message: "Property 'foo' does not exist on type"
+        }
+      ]
     }
   ];
 


### PR DESCRIPTION
Template diagnostics will be placed at invalid positions when the `<template>` block is not on the top of the file. I've fixed how we add `<template>` tag when we pass raw template code to vue-eslint-parser as same as [existing code](https://github.com/vuejs/vetur/blob/master/server/src/modes/template/services/htmlValidation.ts#L24).