### PR TITLE
Avoid virtual template code is broken when attribute name has hyphen

### DIFF
--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -166,7 +166,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
 
   function transformNativeAttribute(attr: AST.VAttribute): ts.ObjectLiteralElementLike {
     return ts.createPropertyAssignment(
-      ts.createIdentifier(attr.key.name),
+      ts.createStringLiteral(attr.key.name),
       attr.value ? ts.createLiteral(attr.value.value) : ts.createLiteral(true)
     );
   }
@@ -245,7 +245,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
       if (name.type === 'VIdentifier') {
         // Attribute name is specified
         // e.g. v-bind:value="foo"
-        return ts.createPropertyAssignment(ts.createIdentifier(name.name), dirExp);
+        return ts.createPropertyAssignment(ts.createStringLiteral(name.name), dirExp);
       } else {
         // Attribute name is dynamic
         // e.g. v-bind:[value]="foo"

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -120,7 +120,7 @@ describe('Should find template-diagnostics in <template> region', () => {
     });
   });
 
-  const noErrorTests: string[] = ['class.vue', 'style.vue'];
+  const noErrorTests: string[] = ['class.vue', 'style.vue', 'hyphen-attrs.vue'];
 
   noErrorTests.forEach(t => {
     it(`Shows no template diagnostics error for ${t}`, async () => {

--- a/test/interpolation/fixture/diagnostics/hyphen-attrs.vue
+++ b/test/interpolation/fixture/diagnostics/hyphen-attrs.vue
@@ -1,0 +1,15 @@
+<template>
+  <div attr-test :prop-test="value" @on-test="value = 'Test'"></div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      value: 'Hello'
+    }
+  }
+})
+</script>


### PR DESCRIPTION
Currently, when a template includes some attribute having hyphen on its name, the virtual Vue template will be broken and provides numerous errors. This is because the transformer try to generate the attribute name as identifier even though hyphen is invalid character as identifier.

I've simply changed them to string literal to accept hyphen.