### PR TITLE
Handle v-on value correctly when it is single expression

### DIFF
--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -183,7 +183,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
   function transformVOn(vOn: AST.VDirective, code: string, scope: string[]): ts.ObjectLiteralElementLike {
     let exp: ts.Expression;
     if (vOn.value && vOn.value.expression) {
-      // value can be ESLintExpression (e.g. ArrowFunctionExpression)
+      // value.expression can be ESLintExpression (e.g. ArrowFunctionExpression)
       const vOnExp = vOn.value.expression as AST.VOnExpression | AST.ESLintExpression;
 
       if (vOnExp.type !== 'VOnExpression') {

--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -183,23 +183,22 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
   function transformVOn(vOn: AST.VDirective, code: string, scope: string[]): ts.ObjectLiteralElementLike {
     let exp: ts.Expression;
     if (vOn.value && vOn.value.expression) {
-      const vOnExp = vOn.value.expression as AST.VOnExpression;
-      const newScope = scope.concat(vOnScope);
+      // value can be ESLintExpression (e.g. ArrowFunctionExpression)
+      const vOnExp = vOn.value.expression as AST.VOnExpression | AST.ESLintExpression;
 
-      // body may be undefined
-      const statements = vOnExp.body ? vOnExp.body.map(st => transformStatement(st, code, newScope)) : [];
-
-      const first = statements[0];
-      if (statements.length === 1 && isPathToIdentifier(first)) {
-        // The v-on expression is simple path to a method
-        // e.g. @click="onClick"
-        exp = first.expression;
+      if (vOnExp.type !== 'VOnExpression') {
+        // The v-on value is an expression of simple path to a method or a function
+        // e.g.
+        //   @click="onClick"
+        //   @click="() => value = 123"
+        exp = parseExpression(vOnExp, code, scope);
       } else {
         // The v-on has some complex expressions or statements.
         // Then wrap them with a function so that they can use `$event` and `arguments`.
         // e.g.
         //   @click="onClick($event, 'test')"
         //   @click="value = "foo""
+        const newScope = scope.concat(vOnScope);
         exp = ts.createCall(ts.createIdentifier(listenerHelperName), undefined, [
           ts.createThis(),
           ts.createFunctionExpression(
@@ -218,7 +217,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
               )
             ],
             undefined,
-            ts.createBlock(statements)
+            ts.createBlock(vOnExp.body.map(st => transformStatement(st, code, newScope)))
           )
         ]);
       }
@@ -490,23 +489,6 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
       return flatMap(filtered, collectScope);
     } else {
       return [];
-    }
-  }
-
-  /**
-   * Return `true` if the statement is a simple path to the identifier.
-   * Examples of `simple path`:
-   *   foo
-   *   this.foo.bar
-   *   list[1]
-   *   record['key']
-   */
-  function isPathToIdentifier(statement: ts.Statement): statement is ts.ExpressionStatement {
-    if (ts.isExpressionStatement(statement)) {
-      const exp = statement.expression;
-      return ts.isIdentifier(exp) || ts.isPropertyAccessExpression(exp);
-    } else {
-      return false;
     }
   }
 

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -48,14 +48,19 @@ describe('Should find template-diagnostics in <template> region', () => {
       file: 'v-on.vue',
       diagnostics: [
         {
-          range: sameLineRange(9, 31, 34),
+          range: sameLineRange(10, 31, 34),
           severity: vscode.DiagnosticSeverity.Error,
           message: "Argument of type '123' is not assignable to parameter of type 'string'"
         },
         {
-          range: sameLineRange(10, 20, 24),
+          range: sameLineRange(11, 20, 24),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Type '"test"' is not assignable to type 'number'`
+        },
+        {
+          range: sameLineRange(12, 20, 28),
+          severity: vscode.DiagnosticSeverity.Error,
+          message: `Property 'notExist' does not exist on type`
         }
       ]
     },

--- a/test/interpolation/fixture/diagnostics/v-on.vue
+++ b/test/interpolation/fixture/diagnostics/v-on.vue
@@ -5,10 +5,12 @@
     <button @click="argumentsTest(arguments)">Arguments Test</button>
     <button @click="eventTest">Reference Test</button>
     <button @click="test = 123">Expression Test</button>
+    <button @click="() => test = 123">Block Statement Test</button>
 
     <!-- Providing errors -->
     <button @click="passString(123)">Invalid Argument Type</button>
     <button @click="test = 'test'">Invalid Update Type</button>
+    <button @click="notExist">Invalid Reference Test</button>
   </div>
 </template>
 
@@ -21,6 +23,7 @@ export default Vue.extend({
       test: 0
     }
   },
+
   methods: {
     // Interface from lib "dom"
     eventTest(event: Event): void {},


### PR DESCRIPTION
fix #1227 

I'd been casting v-on directive value to `AST.VOnExpression` but it actually can be `ESLintExpression` when the value is 1) simple path `@click="foo.bar"` or 2) function expression `@click="() => foo = 123"`.

ref: https://github.com/mysticatea/vue-eslint-parser/blob/0f241279dc412ff4bb0faa9211233a944465f9b4/src/script/index.ts#L816

In the case 1), there was no issues found because it actually ignores the expression and no diagnostic was provided.

The case 2) causes the issue #1227.