### PR TITLE
Fix template literal breaks virtual template file

### DIFF
--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -417,10 +417,14 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
       );
     } else if (ts.isTemplateExpression(exp)) {
       const injectedSpans = exp.templateSpans.map(span => {
-        return ts.createTemplateSpan(injectThis(span.expression, scope, start), span.literal);
+        const literal = ts.isTemplateMiddle(span.literal)
+          ? ts.createTemplateMiddle(span.literal.text)
+          : ts.createTemplateTail(span.literal.text);
+
+        return ts.createTemplateSpan(injectThis(span.expression, scope, start), literal);
       });
 
-      res = ts.createTemplateExpression(exp.head, injectedSpans);
+      res = ts.createTemplateExpression(ts.createTemplateHead(exp.head.text), injectedSpans);
     } else {
       /**
        * Because Nodes can have non-virtual positions

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -125,7 +125,7 @@ describe('Should find template-diagnostics in <template> region', () => {
     });
   });
 
-  const noErrorTests: string[] = ['class.vue', 'style.vue', 'hyphen-attrs.vue'];
+  const noErrorTests: string[] = ['class.vue', 'style.vue', 'hyphen-attrs.vue', 'template-literal.vue'];
 
   noErrorTests.forEach(t => {
     it(`Shows no template diagnostics error for ${t}`, async () => {

--- a/test/interpolation/fixture/diagnostics/template-literal.vue
+++ b/test/interpolation/fixture/diagnostics/template-literal.vue
@@ -1,0 +1,15 @@
+<template>
+  <div :title="`${test}`" />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      test: 'hi'
+    }
+  }
+})
+</script>


### PR DESCRIPTION
fix #1230

I'm not sure the cause but looks like ts printer emits broken template literal when we reuse its AST node for print. Recreating them solves the issue.