### PR TITLE
Fix object literal key breaks virtual template file

### DIFF
--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -441,9 +441,16 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
   ): ts.ObjectLiteralElementLike {
     let res;
     if (ts.isPropertyAssignment(el)) {
-      const name = !ts.isComputedPropertyName(el.name)
-        ? el.name
-        : ts.createComputedPropertyName(injectThis(el.name.expression, scope, start));
+      let name: ts.PropertyName;
+      if (ts.isComputedPropertyName(el.name)) {
+        name = ts.createComputedPropertyName(injectThis(el.name.expression, scope, start));
+      } else if (ts.isStringLiteral(el.name)) {
+        name = ts.createStringLiteral(el.name.text);
+      } else if (ts.isNumericLiteral(el.name)) {
+        name = ts.createNumericLiteral(el.name.text);
+      } else {
+        name = el.name;
+      }
 
       if (!ts.isComputedPropertyName(el.name)) {
         ts.setSourceMapRange(name, { pos: start + el.name.getStart(), end: start + el.name.getEnd() });

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -33,12 +33,12 @@ describe('Should find template-diagnostics in <template> region', () => {
       file: 'object-literal.vue',
       diagnostics: [
         {
-          range: sameLineRange(3, 9, 12),
+          range: sameLineRange(4, 11, 14),
           severity: vscode.DiagnosticSeverity.Error,
           message: "Property 'bar' does not exist on type"
         },
         {
-          range: sameLineRange(4, 4, 7),
+          range: sameLineRange(5, 6, 9),
           severity: vscode.DiagnosticSeverity.Error,
           message: "Property 'baz' does not exist on type"
         }

--- a/test/interpolation/fixture/diagnostics/object-literal.vue
+++ b/test/interpolation/fixture/diagnostics/object-literal.vue
@@ -1,9 +1,13 @@
 <template>
-  <p :class="{
-    foo: foo,
-    bar: bar,
-    baz
-  }">Hello</p>
+  <div>
+    <p :class="{
+      foo: foo,
+      bar: bar,
+      baz
+    }">Hello</p>
+
+    <p :class="{ 'string': true, 1234567890: true }">Literal Keys</p>
+  </div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Possibly fix... #1237 

This is the same kind of issue with #1244. String and Numeric literal in object literal property key emits invalid characters when reusing AST.