### PR TITLE
Add suggestion diagnostics from TS Server

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -110,7 +110,8 @@ export async function getJavascriptMode(
       const fileFsPath = getFileFsPath(doc.uri);
       const rawScriptDiagnostics = [
         ...service.getSyntacticDiagnostics(fileFsPath),
-        ...service.getSemanticDiagnostics(fileFsPath)
+        ...service.getSemanticDiagnostics(fileFsPath),
+        ...service.getSuggestionDiagnostics(fileFsPath)
       ];
 
       return rawScriptDiagnostics.map(diag => {


### PR DESCRIPTION
Adds `getSuggestionDiagnostics` to the list of diagnostic contribution points, which provides things like hinting & fixes for unused imports.


![2019-04-28_04-40-59](https://user-images.githubusercontent.com/2995953/56857611-26387a80-6970-11e9-946a-2467e66563cf.gif)
