### PR TITLE
Support statement expression in arrow function block

### DIFF
--- a/server/src/services/typescriptService/test/transformTemplate.test.ts
+++ b/server/src/services/typescriptService/test/transformTemplate.test.ts
@@ -112,6 +112,10 @@ suite('transformTemplate', () => {
       );
     });
 
+    test('ArrowFunction: statement block', () => {
+      check('(bar) => { foo + bar; }', '(bar) => { this.foo + bar; }');
+    });
+
     test('TemplateExpression', () => {
       check('`font-size: ${size}px`', '`font-size: ${this.size}px`');
     });


### PR DESCRIPTION
By this PR, interpolation service supports following usage:

```vue
<template>
  <button @click="() => { foo + 1 }">Increment</button>
</template>
```

I only transform `StatementExpression` in arrow function block because no one would use other statements in template...