### PR TITLE
fix: Re-add Quasar Framework pre v1 support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 Vue tooling for VS Code, powered by [vue-language-server](https://github.com/vuejs/vetur/tree/master/server).
 
-Try it out with [Veturpack](https://github.com/octref/veturpack)!  
+Try it out with [Veturpack](https://github.com/octref/veturpack)!
 
 🎉 VueConf 2017 [Slide](https://www.dropbox.com/sh/eb4w8k3orh0j391/AAB3HaJexbGLa2tCP14BI8oJa?dl=0) & [Video](https://www.youtube.com/watch?v=05tNXJ-Kric) 🎉
 
@@ -23,7 +23,7 @@ You can [open an issue](https://github.com/vuejs/vetur/issues/new) for bugs or f
 - [Formatting](formatting.md)
 - [IntelliSense](intellisense.md)
 - [Debugging](debugging.md)
-- [Framework Support](framework.md) for [Element UI](http://element.eleme.io) and [Onsen UI](https://onsen.io)
+- [Framework Support](framework.md) for [Element UI](http://element.eleme.io), [Onsen UI](https://onsen.io) and [Quasar Framework](https://quasar-framework.org)
 
 ## Quick Start
 
@@ -38,4 +38,4 @@ You can [open an issue](https://github.com/vuejs/vetur/issues/new) for bugs or f
 
 ## License
 
-MIT © [Pine Wu](https://github.com/octref) 
+MIT © [Pine Wu](https://github.com/octref)

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -29,7 +29,7 @@ Vetur reads the `package.json` **in your project root** to determine if it shoul
 | `gridsome` | [gridsome-helper-json](https://github.com/gridsome/gridsome-helper-json) |
 | `nuxt` / `nuxt-legacy` / `nuxt-ts` | Bundled in [@nuxt/vue-app](https://www.npmjs.com/package/@nuxt/vue-app) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
 | `nuxt-edge` / `nuxt-ts-edge` | Bundled in [@nuxt/vue-app-edge](https://www.npmjs.com/package/@nuxt/vue-app-edge) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) |
-| `quasar-framework` | Bundled in [quasar](https://www.npmjs.com/package/quasar) package |
+| `quasar` / `quasar-framework` | Bundled in [quasar](https://www.npmjs.com/package/quasar) (v1+) and [quasar-framework](https://www.npmjs.com/package/quasar-framework) (pre v1) packages |
 
 Getting `element-ui`'s completions is as easy as running `yarn add element-ui` and reloading VS Code.
 

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -45,7 +45,8 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     bootstrap: false,
     buefy: false,
     vuetify: false,
-    quasar: false,
+    quasar: false, // Quasar v1+
+    'quasar-framework': false, // Quasar pre v1
     nuxt: false,
     gridsome: false
   };
@@ -58,30 +59,46 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
       return settings;
     }
     const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
-    if (packageJson.dependencies['vue-router']) {
+    const dependencies = packageJson.dependencies;
+
+    if (dependencies['vue-router']) {
       settings['router'] = true;
     }
-    if (packageJson.dependencies['element-ui']) {
+    if (dependencies['element-ui']) {
       settings['element'] = true;
     }
-    if (packageJson.dependencies['vue-onsenui']) {
+    if (dependencies['vue-onsenui']) {
       settings['onsen'] = true;
     }
-    if (packageJson.dependencies['bootstrap-vue']) {
+    if (dependencies['bootstrap-vue']) {
       settings['bootstrap'] = true;
     }
-    if (packageJson.dependencies['buefy']) {
+    if (dependencies['buefy']) {
       settings['buefy'] = true;
     }
-    if (packageJson.dependencies['vuetify']) {
+    if (dependencies['vuetify']) {
       settings['vuetify'] = true;
     }
+    // Quasar v1+:
+    if (dependencies['quasar']) {
+      settings['quasar'] = true;
+    }
+    // Quasar pre v1 on non quasar-cli:
+    if (dependencies['quasar-framework']) {
+      settings['quasar-framework'] = true;
+    }
+    // Quasar pre v1 on quasar-cli:
+    if (packageJson.devDependencies && packageJson.devDependencies['quasar-cli']) {
+      // pushing dependency so we can check it
+      // and enable Quasar later below in the for()
+      dependencies['quasar-framework'] = '^0.0.17';
+    }
     if (
-      packageJson.dependencies['nuxt'] ||
-      packageJson.dependencies['nuxt-legacy'] ||
-      packageJson.dependencies['nuxt-edge'] ||
-      packageJson.dependencies['nuxt-ts'] ||
-      packageJson.dependencies['nuxt-ts-edge']
+      dependencies['nuxt'] ||
+      dependencies['nuxt-legacy'] ||
+      dependencies['nuxt-edge'] ||
+      dependencies['nuxt-ts'] ||
+      dependencies['nuxt-ts-edge']
     ) {
       const nuxtTagProvider = getNuxtTagProvider(workspacePath);
       if (nuxtTagProvider) {
@@ -89,11 +106,11 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
         allTagProviders.push(nuxtTagProvider);
       }
     }
-    if (packageJson.dependencies['gridsome']) {
+    if (dependencies['gridsome']) {
       settings['gridsome'] = true;
     }
 
-    for (const dep in packageJson.dependencies) {
+    for (const dep in dependencies) {
       const runtimePkgPath = ts.findConfigFile(
         workspacePath,
         ts.sys.fileExists,

--- a/test/lsp-ts-28/fixture/package.json
+++ b/test/lsp-ts-28/fixture/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "element-ui": "^2.4.5",
     "lodash": "^4.17.4",
-    "quasar-framework": "^0.17.12",
+    "quasar": "^1.0.0-beta.0",
     "vue": "^2.5.3",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"

--- a/test/lsp-ts-28/fixture/yarn.lock
+++ b/test/lsp-ts-28/fixture/yarn.lock
@@ -1251,10 +1251,10 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-quasar-framework@^0.17.12:
-  version "0.17.12"
-  resolved "https://registry.yarnpkg.com/quasar-framework/-/quasar-framework-0.17.12.tgz#76d4d094f3ca78108ae8436a810cb00ab55b93e5"
-  integrity sha512-hSv8Sx7mD+M6JFuQJJqc4BaKRB3cEWnYyOOwbsbEd2ks23GPXQKnz2UorYum03GSgzN9f8e6N2/IRjXSKWjvkQ==
+quasar@^1.0.0-beta.0:
+  version "1.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/quasar/-/quasar-1.0.0-beta.20.tgz#71f4ec4f31a4cd9d43cda623e7b987b1084099ee"
+  integrity sha512-oI0dlUsNVQl6WXkT6W8OesNCT0K4oAU20OTRgiid7+hngTTfDJa8UYfzKxq1jUogiRSFjvRoHU95EVlhHP7kUA==
 
 quick-lru@^1.0.0:
   version "1.1.0"

--- a/test/lsp/fixture/package.json
+++ b/test/lsp/fixture/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "element-ui": "^2.4.5",
     "lodash": "^4.17.4",
-    "quasar-framework": "^0.17.12",
+    "quasar": "^1.0.0-beta.0",
     "vue": "^2.6.10",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"

--- a/test/lsp/fixture/yarn.lock
+++ b/test/lsp/fixture/yarn.lock
@@ -1251,10 +1251,10 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-quasar-framework@^0.17.12:
-  version "0.17.12"
-  resolved "https://registry.yarnpkg.com/quasar-framework/-/quasar-framework-0.17.12.tgz#76d4d094f3ca78108ae8436a810cb00ab55b93e5"
-  integrity sha512-hSv8Sx7mD+M6JFuQJJqc4BaKRB3cEWnYyOOwbsbEd2ks23GPXQKnz2UorYum03GSgzN9f8e6N2/IRjXSKWjvkQ==
+quasar@^1.0.0-beta.0:
+  version "1.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/quasar/-/quasar-1.0.0-beta.20.tgz#71f4ec4f31a4cd9d43cda623e7b987b1084099ee"
+  integrity sha512-oI0dlUsNVQl6WXkT6W8OesNCT0K4oAU20OTRgiid7+hngTTfDJa8UYfzKxq1jUogiRSFjvRoHU95EVlhHP7kUA==
 
 quick-lru@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
TLDR; **I added support for the `vetur` Object in package.json (which specifies the location of Vetur's needed tags and attributes jsons) specifically for Quasar. A later change in Vetur code made this feature available for all frameworks, but removed Quasar support as a result, which is ironic.** Quasar developers are missing the autocompletion feature since 5 November.

### Reasoning

This PR re-adds support for Quasar Framework (< v1) when using Quasar CLI.

I initially introduced the concept of using package.json > vetur Object to specify the location of vetur tags and attributes file with [PR](https://github.com/vuejs/vetur/commit/038fe3774cafbdaeda6b6877e1bff21deeb8619d#diff-edc9333e4c2f452171b45de5fcbe9376R28). This was done for Quasar Framework only.

Later on, this concept became the default way of dealing with any frameworks through [PR](https://github.com/vuejs/vetur/commit/d42b662762ed48f10ff2a1528759e5abc41a7b00#diff-f0b24377167be7ffee9c03f0072ba2fd) by @Zenser . But while introducing this, Quasar became undetectable, so its support dropped.

In a Quasar CLI project folder, Quasar Framework pre v1 (eg: v0.17) is supplied by `quasar-cli` package which is specified in package.json > devDependencies through `quasar-framework` package (`quasar-framework` is a dependency of `quasar-cli`, not of the project itself). This was missed by @Zenser 's PR, because Vetur ended up checking quasar-cli's package.json for the `vetur` Object that I introduced -- which is not there. My initial code was detecting `quasar-cli` package and then it was checking `node_modules/quasar-framework/package.json` to get the details. My initial PR added a test-case specifically for Quasar, but it was directly using `quasar-framework` package as a dependency (as in Vue CLI usage of a project with Quasar), instead of `quasar-cli`. So the tests were successful -- since `quasar-framework` dependency was specified in the test project folder, which is the NPM package that has the vetur Object in its package.json.

The current PR detects if `quasar-cli` is specified in a project's devDependencies and virtually adds `quasar-framework` to the in-memory package.json > dependencies. This allows Vetur to correctly get the provider a few lines below this in the `for(dep in dependencies)`.

