### PR TITLE
Infer $event type more accurately

### DIFF
--- a/server/src/services/typescriptService/bridge.ts
+++ b/server/src/services/typescriptService/bridge.ts
@@ -14,7 +14,7 @@ type ComponentListeners<T> = {
 interface ComponentData<T> {
   props: Record<string, any>;
   on: ComponentListeners<T>;
-  directives: any[]
+  directives: any[];
 }
 export declare const ${renderHelperName}: {
   <T>(Component: (new (...args: any[]) => T), fn: (this: T) => any): any;

--- a/server/src/services/typescriptService/bridge.ts
+++ b/server/src/services/typescriptService/bridge.ts
@@ -1,4 +1,4 @@
-import { renderHelperName, componentHelperName, iterationHelperName, listenerHelperName } from './transformTemplate';
+import { renderHelperName, componentHelperName, iterationHelperName } from './transformTemplate';
 
 // This bridge file will be injected into TypeScript language service
 // it enable type checking and completion, yet still preserve precise option type
@@ -8,20 +8,30 @@ export const moduleName = 'vue-editor-bridge';
 export const fileName = 'vue-temp/vue-editor-bridge.ts';
 
 const renderHelpers = `
+type ComponentListeners<T> = {
+  [K in keyof T]?: ($event: T[K]) => any;
+};
+interface ComponentData<T> {
+  props: Record<string, any>;
+  on: ComponentListeners<T>;
+  directives: any[]
+}
 export declare const ${renderHelperName}: {
   <T>(Component: (new (...args: any[]) => T), fn: (this: T) => any): any;
 };
 export declare const ${componentHelperName}: {
-  (tag: string, data: any, children: any[]): any;
+  <T>(
+    vm: T,
+    tag: string,
+    data: ComponentData<HTMLElementEventMap & Record<string, any>> & ThisType<T>,
+    children: any[]
+  ): any;
 };
 export declare const ${iterationHelperName}: {
   <T>(list: T[], fn: (value: T, index: number) => any): any;
   <T>(obj: { [key: string]: T }, fn: (value: T, key: string, index: number) => any): any;
   (num: number, fn: (value: number) => any): any;
   <T>(obj: object, fn: (value: any, key: string, index: number) => any): any;
-};
-export declare const ${listenerHelperName}: {
-  <T>(vm: T, listener: (this: T, ...args: any[]) => any): any;
 };
 `;
 

--- a/server/src/services/typescriptService/preprocess.ts
+++ b/server/src/services/typescriptService/preprocess.ts
@@ -10,8 +10,7 @@ import {
   getTemplateTransformFunctions,
   componentHelperName,
   iterationHelperName,
-  renderHelperName,
-  listenerHelperName
+  renderHelperName
 } from './transformTemplate';
 import { templateSourceMap } from './serviceHost';
 import { generateSourceMap } from './sourceMap';
@@ -236,8 +235,7 @@ export function injectVueTemplate(
       tsModule.createNamedImports([
         tsModule.createImportSpecifier(undefined, tsModule.createIdentifier(renderHelperName)),
         tsModule.createImportSpecifier(undefined, tsModule.createIdentifier(componentHelperName)),
-        tsModule.createImportSpecifier(undefined, tsModule.createIdentifier(iterationHelperName)),
-        tsModule.createImportSpecifier(undefined, tsModule.createIdentifier(listenerHelperName))
+        tsModule.createImportSpecifier(undefined, tsModule.createIdentifier(iterationHelperName))
       ])
     ),
     tsModule.createLiteral('vue-editor-bridge')

--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -171,7 +171,14 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
       if (!vOn.key.argument) {
         // e.g.
         //   v-on="$listeners"
-        exp = vOnExp.type !== 'VOnExpression' ? parseExpression(vOnExp, code, scope) : ts.createObjectLiteral([]);
+
+        // Annotate the expression with `any` because we do not expect type error
+        // with bridge type and it. Currently, bridge type should only be used
+        // for inferring `$event` type.
+        exp = ts.createAsExpression(
+          vOnExp.type !== 'VOnExpression' ? parseExpression(vOnExp, code, scope) : ts.createObjectLiteral([]),
+          ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)
+        );
       } else {
         // e.g.
         //   @click="onClick"
@@ -187,7 +194,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
           undefined,
           undefined,
           undefined,
-          [ts.createParameter(undefined, undefined, undefined, '$event', undefined, undefined)],
+          [ts.createParameter(undefined, undefined, undefined, '$event')],
           undefined,
           ts.createBlock(statements)
         );

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -127,17 +127,23 @@ describe('Should find template-diagnostics in <template> region', () => {
       file: 'v-on.vue',
       diagnostics: [
         {
-          range: sameLineRange(10, 31, 34),
+          range: sameLineRange(11, 31, 34),
           severity: vscode.DiagnosticSeverity.Error,
           message: "Argument of type '123' is not assignable to parameter of type 'string'"
         },
         {
-          range: sameLineRange(11, 20, 24),
+          range: sameLineRange(12, 20, 24),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Type '"test"' is not assignable to type 'number'`
         },
         {
-          range: sameLineRange(12, 20, 28),
+          range: sameLineRange(13, 20, 28),
+          severity: vscode.DiagnosticSeverity.Error,
+          message: `Property 'notExist' does not exist on type`
+        },
+
+        {
+          range: sameLineRange(14, 27, 35),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Property 'notExist' does not exist on type`
         }

--- a/test/interpolation/fixture/diagnostics/v-on.vue
+++ b/test/interpolation/fixture/diagnostics/v-on.vue
@@ -6,11 +6,13 @@
     <button @click="eventTest">Reference Test</button>
     <button @click="test = 123">Expression Test</button>
     <button @click="() => test = 123">Block Statement Test</button>
+    <button v-on="{ click: eventTest }">Object Style Test</button>
 
     <!-- Providing errors -->
     <button @click="passString(123)">Invalid Argument Type</button>
     <button @click="test = 'test'">Invalid Update Type</button>
     <button @click="notExist">Invalid Reference Test</button>
+    <button v-on="{ click: notExist }">Invalid Object Style Test</button>
   </div>
 </template>
 
@@ -26,7 +28,7 @@ export default Vue.extend({
 
   methods: {
     // Interface from lib "dom"
-    eventTest(event: Event): void {},
+    eventTest(event: MouseEvent): void {},
     // Interface from lib "es5"
     argumentsTest(args: IArguments): void {},
     passString(str: string): void {}


### PR DESCRIPTION
fix #1281 

Utilizing `HTMLElementEventMap` which has all possible event name and event type pairs for `$event` type.

Note that `ComponentData` bridge type is only meant to be used for inferring `$event` type currently. So it will skip type check in case of passing method name directly and `v-on` without argument like below:

```vue
<template>
  <div>
    <!-- Error: mismatching onClick arg type and $event type -->
    <input @keydown="onClick($event)" />
    
    <!-- NOT Error: it does not check implicit argument type -->
    <input @keydown="onClick" />
    
    <!-- NOT Error -->
    <input v-on="{ keydown: onClick }" />
  </div>
</template>

<script lang="ts">
import Vue from 'vue'

export default Vue.extend({
  methods: {
    onClick(event: MouseEvent): void {}
  }
})
</script>
```

This is because there are no guarantee that the event is from native DOM elements. e.g. when some Vue component emits string value via `change` event which is the same name with native DOM event but not value type.

On the other hand, `$event` will only be used in native event handlers. So we can safely infer its type from `HTMLElementEventMap`.

In the future, we would be able to analyze it more accurate if we can detect which tag in template is component.