### PR TITLE
Relax $event type to any

### DIFF
--- a/server/src/services/typescriptService/bridge.ts
+++ b/server/src/services/typescriptService/bridge.ts
@@ -23,7 +23,7 @@ export declare const ${componentHelperName}: {
   <T>(
     vm: T,
     tag: string,
-    data: ComponentData<HTMLElementEventMap & Record<string, any>> & ThisType<T>,
+    data: ComponentData<Record<string, any>> & ThisType<T>,
     children: any[]
   ): any;
 };


### PR DESCRIPTION
fix #1306 

I said `$event` is only used native event handler but it was not true actually.
We can use it in component event handler and it refers the first parameter of event.
https://vuejs.org/v2/guide/components.html#Emitting-a-Value-With-an-Event

I guess we should relax its type to `any` until we can detect component tag in future.