### PR TITLE
substitute `createStatement` with `createExpressionStatement`

### DIFF
--- a/server/src/services/typescriptService/preprocess.ts
+++ b/server/src/services/typescriptService/preprocess.ts
@@ -243,8 +243,8 @@ export function injectVueTemplate(
 
   // wrap render code with a function decralation
   // with `this` type of component.
-  const statements = renderBlock.map(exp => tsModule.createStatement(exp));
-  const renderElement = tsModule.createStatement(
+  const statements = renderBlock.map(exp => tsModule.createExpressionStatement(exp));
+  const renderElement = tsModule.createExpressionStatement(
     tsModule.createCall(tsModule.createIdentifier(renderHelperName), undefined, [
       // Reference to the component
       tsModule.createIdentifier('__Component'),

--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -186,7 +186,7 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
         const newScope = scope.concat(vOnScope);
         const statements =
           vOnExp.type !== 'VOnExpression'
-            ? [ts.createStatement(parseExpression(vOnExp, code, newScope))]
+            ? [ts.createExpressionStatement(parseExpression(vOnExp, code, newScope))]
             : vOnExp.body.map(st => transformStatement(st, code, newScope));
 
         exp = ts.createFunctionExpression(
@@ -501,10 +501,10 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
   function transformStatement(statement: AST.ESLintStatement, code: string, scope: string[]): ts.Statement {
     if (statement.type !== 'ExpressionStatement') {
       console.error('Unexpected statement type:', statement.type);
-      return ts.createStatement(ts.createLiteral(''));
+      return ts.createExpressionStatement(ts.createLiteral(''));
     }
 
-    return ts.createStatement(parseExpression(statement.expression, code, scope));
+    return ts.createExpressionStatement(parseExpression(statement.expression, code, scope));
   }
 
   function transformFilter(filter: AST.VFilterSequenceExpression, code: string, scope: string[]): ts.Expression {


### PR DESCRIPTION
`createStatement` is deprecated, use `createExpressionStatement` instead.