### PR TITLE
Avoid template diagnostic error on empty v-on

### DIFF
--- a/server/src/services/typescriptService/transformTemplate.ts
+++ b/server/src/services/typescriptService/transformTemplate.ts
@@ -201,7 +201,15 @@ export function getTemplateTransformFunctions(ts: T_TypeScript) {
       }
     } else {
       // There are no statement in v-on value
-      exp = ts.createLiteral(true);
+      exp = ts.createFunctionExpression(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ts.createBlock([])
+      );
     }
 
     return directiveToObjectElement(vOn, exp, code, scope);

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -127,23 +127,23 @@ describe('Should find template-diagnostics in <template> region', () => {
       file: 'v-on.vue',
       diagnostics: [
         {
-          range: sameLineRange(11, 31, 34),
+          range: sameLineRange(12, 31, 34),
           severity: vscode.DiagnosticSeverity.Error,
           message: "Argument of type '123' is not assignable to parameter of type 'string'"
         },
         {
-          range: sameLineRange(12, 20, 24),
+          range: sameLineRange(13, 20, 24),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Type '"test"' is not assignable to type 'number'`
         },
         {
-          range: sameLineRange(13, 20, 28),
+          range: sameLineRange(14, 20, 28),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Property 'notExist' does not exist on type`
         },
 
         {
-          range: sameLineRange(14, 27, 35),
+          range: sameLineRange(15, 27, 35),
           severity: vscode.DiagnosticSeverity.Error,
           message: `Property 'notExist' does not exist on type`
         }

--- a/test/interpolation/fixture/diagnostics/v-on.vue
+++ b/test/interpolation/fixture/diagnostics/v-on.vue
@@ -7,6 +7,7 @@
     <button @click="test = 123">Expression Test</button>
     <button @click="() => test = 123">Block Statement Test</button>
     <button v-on="{ click: eventTest }">Object Style Test</button>
+    <button @click.stop>Empty Value Test</button>
 
     <!-- Providing errors -->
     <button @click="passString(123)">Invalid Argument Type</button>


### PR DESCRIPTION
Sometimes the users want to write `v-on` with empty value like `@click.stop`. In this case, Vetur produce an error because it passes `true` as the value on virtual source file.

![Screenshot 2019-07-30 at 10 18 23 AM](https://user-images.githubusercontent.com/2194624/62096729-43eee600-b2b7-11e9-8fa3-15b12509f4e8.png)

Changing the value to noop solves this issue.
