### PR TITLE
bump typescript on vue-language-server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
     "resolve": "^1.8.1",
     "stylus": "^0.54.5",
     "stylus-supremacy": "^2.12.6",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.5.3",
     "vscode-css-languageservice": "^4.0.2-next.3",
     "vscode-emmet-helper": "^1.1.19",
     "vscode-languageserver": "^5.3.0-next.4",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -4518,10 +4518,10 @@ typescript@^2.5.1:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
 
-typescript@^3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
fix #1389 

I didn't update it to 3.6.2 because it has some issue with Vue.js typing.