### PR TITLE
Apply template interpolation validation only to TypeScript components

### DIFF
--- a/server/src/modes/template/index.ts
+++ b/server/src/modes/template/index.ts
@@ -33,7 +33,7 @@ export class VueHTMLMode implements LanguageMode {
   ) {
     const vueDocuments = getLanguageModelCache<HTMLDocument>(10, 60, document => parseHTMLDocument(document));
     this.htmlMode = new HTMLMode(documentRegions, workspacePath, vueDocuments, vueInfoService);
-    this.vueInterpolationMode = new VueInterpolationMode(tsModule, serviceHost, vueDocuments);
+    this.vueInterpolationMode = new VueInterpolationMode(tsModule, serviceHost, vueDocuments, vueInfoService);
   }
   getId() {
     return 'vue-html';

--- a/server/src/modes/template/interpolationMode.ts
+++ b/server/src/modes/template/interpolationMode.ts
@@ -50,7 +50,7 @@ export class VueInterpolationMode implements LanguageMode {
   }
 
   doValidation(document: TextDocument): Diagnostic[] {
-    if (!this.interpolationEnabledInTypeScriptDocument(document)) {
+    if (!this.interpolationEnabled || !this.documentTypeChecked(document)) {
       return [];
     }
 
@@ -218,7 +218,7 @@ export class VueInterpolationMode implements LanguageMode {
     contents: MarkedString[];
     range?: Range;
   } {
-    if (!this.interpolationEnabledInTypeScriptDocument(document)) {
+    if (!this.interpolationEnabled()) {
       return { contents: [] };
     }
 
@@ -257,7 +257,7 @@ export class VueInterpolationMode implements LanguageMode {
   }
 
   findDefinition(document: TextDocument, position: Position): Location[] {
-    if (!this.interpolationEnabledInTypeScriptDocument(document)) {
+    if (!this.interpolationEnabled()) {
       return [];
     }
 
@@ -305,7 +305,7 @@ export class VueInterpolationMode implements LanguageMode {
   }
 
   findReferences(document: TextDocument, position: Position): Location[] {
-    if (!this.interpolationEnabledInTypeScriptDocument(document)) {
+    if (!this.interpolationEnabled()) {
       return [];
     }
 
@@ -356,12 +356,11 @@ export class VueInterpolationMode implements LanguageMode {
 
   dispose() {}
 
-  private interpolationEnabledInTypeScriptDocument(document: TextDocument): boolean {
-    const documentIncludesTypeScript =
-      !!this.vueInfoService && this.vueInfoService.documentIncludesLanguage(document, 'typescript');
-    return (
-      _.get(this.config, ['vetur', 'experimental', 'templateInterpolationService'], true) && documentIncludesTypeScript
-    );
+  private interpolationEnabled(): boolean {
+    return _.get(this.config, ['vetur', 'experimental', 'templateInterpolationService'], true);
+  }
+  private documentTypeChecked(document: TextDocument): boolean {
+    return !!this.vueInfoService && this.vueInfoService.documentIncludesLanguage(document, 'typescript');
   }
 }
 

--- a/server/src/services/vueInfoService.ts
+++ b/server/src/services/vueInfoService.ts
@@ -2,6 +2,7 @@ import { TextDocument } from 'vscode-languageserver';
 import { getFileFsPath } from '../utils/paths';
 import { Definition } from 'vscode-languageserver-types';
 import { LanguageModes } from '../embeddedSupport/languageModes';
+import { LanguageId } from '../embeddedSupport/embeddedSupport';
 
 /**
  * State associated with a specific Vue file
@@ -81,5 +82,9 @@ export class VueInfoService {
       }
     });
     return this.vueFileInfo.get(getFileFsPath(doc.uri));
+  }
+
+  documentIncludesLanguage(doc: TextDocument, languageId: LanguageId): boolean {
+    return this.languageModes.getAllLanguageModeRangesInDocument(doc).some(m => m.languageId === languageId);
   }
 }

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -250,7 +250,13 @@ describe('Should find template-diagnostics in <template> region', () => {
     });
   });
 
-  const noErrorTests: string[] = ['class.vue', 'style.vue', 'hyphen-attrs.vue', 'template-literal.vue'];
+  const noErrorTests: string[] = [
+    'class.vue',
+    'style.vue',
+    'hyphen-attrs.vue',
+    'template-literal.vue',
+    'no-type-check.vue'
+  ];
 
   noErrorTests.forEach(t => {
     it(`Shows no template diagnostics error for ${t}`, async () => {

--- a/test/interpolation/fixture/diagnostics/no-type-check.vue
+++ b/test/interpolation/fixture/diagnostics/no-type-check.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <div>{{ accessNonexistentProperty }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      msg: 'foo'
+    }
+  },
+  computed: {
+    accessNonexistentProperty() {
+      return this.message
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Hi @ktsn - thanks for the direction on this in #1427 

The PR checks if the current document includes `typescript` as a language; if it does not, the template interpolation service will no longer attempt to do validation on that document. As you suggested [here](https://github.com/vuejs/vetur/issues/1427#issuecomment-533380654), though, the other, non-diagnostic features associated with the interpolation service will continue to run, so long as the user has enabled the feature in their settings.

**What I still need assistance with:**
* I'm not certain how we should be checking for `// @ts-check`. Do you happen to know if the `typescript` module provides information about "yes, this file is being type-checked, whether because of its extension or the ts-check directive"? Otherwise, presumably we need to parse the beginning of the script, to find that actual text?
* I wanted to confirm that the method of checking the languages in the current document is OK; after a fair amount of digging, I couldn't find an alternative approach in the codebase

Please absolute suggest any changes or alternative approaches; just wanted to get an initial approach out there. There are currently 2 failing `interpolation` tests; the JSDoc case can certainly be handled if we figure out how to capture the `ts-check` directive 