### PR TITLE
Analyze invalid interpolation expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.23.0
+
+- Support analyzing invalid template interpolation expression. #1448.
+
 ### 0.22.4 | 2019-10-01 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.22.4/vspackage)
 
 - Improve performance by caching module resolution results. #1442.

--- a/server/src/services/typescriptService/test/transformTemplate.test.ts
+++ b/server/src/services/typescriptService/test/transformTemplate.test.ts
@@ -6,7 +6,7 @@ suite('transformTemplate', () => {
   suite('`this` injection', () => {
     function check(inputTsCode: string, expectedTsCode: string, scope: string[] = []): void {
       const source = ts.createSourceFile('test.ts', inputTsCode, ts.ScriptTarget.Latest, true);
-      const output = getTemplateTransformFunctions(require('typescript')).parseExpressionImpl(source.text, scope, 0);
+      const output = getTemplateTransformFunctions(require('typescript')).parseExpression(source.text, scope, 0);
 
       const printer = ts.createPrinter();
       const outputStr = printer.printNode(ts.EmitHint.Expression, output, source);


### PR DESCRIPTION
This PR fixes the problem I stated in #1446.

The reason an invalid expression has gone from source map node is because ESLint does not provide any AST when it is invalid. In the previous implementation, we use range data from ESLintExpression, then we couldn't take an invalid expression when setting source map range.

This PR makes it uses VExpressionContainer which always provides range data whether the contained expression is invalid or not.