### PR TITLE
Fixed an issue with file paths in javascript mode on windows.

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -33,6 +33,7 @@ import { getFileFsPath, getFilePath } from '../../utils/paths';
 import Uri from 'vscode-uri';
 import * as ts from 'typescript';
 import * as _ from 'lodash';
+import * as path from 'path';
 
 import { nullMode, NULL_SIGNATURE } from '../nullMode';
 import { VLSFormatConfig } from '../../config';
@@ -639,7 +640,7 @@ function getSourceDoc(fileName: string, program: ts.Program): TextDocument {
 export function languageServiceIncludesFile(ls: ts.LanguageService, documentUri: string): boolean {
   const filePaths = ls.getProgram()!.getRootFileNames();
   const filePath = getFilePath(documentUri);
-  return filePaths.includes(filePath);
+  return filePaths.includes(path.normalize(filePath));
 }
 
 function convertRange(document: TextDocument, span: ts.TextSpan): Range {

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -279,8 +279,7 @@ export class VLS {
     const doc = this.documentService.getDocument(textDocument.uri)!;
     const mode = this.languageModes.getModeAtPosition(doc, position);
     if (mode && mode.doComplete) {
-      const res = mode.doComplete(doc, position);
-      return res;
+      return mode.doComplete(doc, position);
     }
 
     return NULL_COMPLETION;

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -100,10 +100,14 @@ export class VLS {
         : false
     );
 
-    await this.languageModes.init(workspacePath, {
-      infoService: this.vueInfoService,
-      dependencyService: this.dependencyService
-    }, params.initializationOptions['globalSnippetDir']);
+    await this.languageModes.init(
+      workspacePath,
+      {
+        infoService: this.vueInfoService,
+        dependencyService: this.dependencyService
+      },
+      params.initializationOptions['globalSnippetDir']
+    );
 
     this.setupConfigListeners();
     this.setupLSPHandlers();
@@ -275,7 +279,8 @@ export class VLS {
     const doc = this.documentService.getDocument(textDocument.uri)!;
     const mode = this.languageModes.getModeAtPosition(doc, position);
     if (mode && mode.doComplete) {
-      return mode.doComplete(doc, position);
+      const res = mode.doComplete(doc, position);
+      return res;
     }
 
     return NULL_COMPLETION;


### PR DESCRIPTION
I work almost exclusively on Windows, and autocomplete barely ever worked. Turns out that the function "languageServiceIncludesFile" checked if the file is inside the project, but used two different types of formatting. The list of filePaths uses "\" and filePath uses "/". Normalizing the path fixed the issue. 

I copied the two variables into chrome for better readability and this was the result before the fix:
![image](https://user-images.githubusercontent.com/18658863/67265371-d87b7580-f4ad-11e9-9276-76fb6e717dca.png)

