### PR TITLE
Add FAQ section to describe workspace dep setting

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -93,3 +93,7 @@ vsce package
 ```
   
 Now you'll find `vetur-{version}.vsix`, you can install it by editor command "Install from VSIX".
+
+## Vetur uses different version of TypeScript in .vue files to what I installed in `node_modules`.
+
+You should enable `Vetur: Use Workspace Dependencies` setting so that it uses the same version of TypeScript in your workspace.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,4 +96,4 @@ Now you'll find `vetur-{version}.vsix`, you can install it by editor command "In
 
 ## Vetur uses different version of TypeScript in .vue files to what I installed in `node_modules`.
 
-You should enable `Vetur: Use Workspace Dependencies` setting so that it uses the same version of TypeScript in your workspace.
+You can enable `Vetur: Use Workspace Dependencies` setting so that it uses the same version of TypeScript in your workspace.


### PR DESCRIPTION
I have been seeing many people do not know about `Vetur: Use Workspace Dependencies` setting and ask question on this repo's issue list or other forum. Adding a section about it in FAQ may be helpful.