### PR TITLE
quasar as devDependency

### DIFF
--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -83,7 +83,7 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
       dependencies['vuetify'] = true;
     }
     // Quasar v1+:
-    if (dependencies['quasar']) {
+    if (dependencies['quasar'] || devDependencies['quasar']) {
       settings['quasar'] = true;
     }
     // Quasar pre v1 on non quasar-cli:


### PR DESCRIPTION
I suggest allowing quasar to be a devDependency to allow code completion in app extensions without adding a dependency.

https://github.com/quasarframework/quasar-starter-kit-app-extension/issues/10