### PR TITLE
Runtime Tag providers for workspace package.json

### DIFF
--- a/server/src/modes/template/tagProviders/externalTagProviders.ts
+++ b/server/src/modes/template/tagProviders/externalTagProviders.ts
@@ -25,21 +25,13 @@ export const bootstrapTagProvider = getExternalTagProvider('bootstrap', bootstra
 export const buefyTagProvider = getExternalTagProvider('buefy', buefyTags, buefyAttributes);
 export const gridsomeTagProvider = getExternalTagProvider('gridsome', gridsomeTags, gridsomeAttributes);
 
-export function getRuntimeTagProvider(workspacePath: string, pkg: any): IHTMLTagProvider | null {
+export function getRuntimeTagProvider(workspaceOrDependencyPath: string, pkg: any): IHTMLTagProvider | null {
   if (!pkg.vetur) {
     return null;
   }
 
-  const tagsPath = ts.findConfigFile(
-    workspacePath,
-    ts.sys.fileExists,
-    path.join('node_modules/', pkg.name, pkg.vetur.tags)
-  );
-  const attrsPath = ts.findConfigFile(
-    workspacePath,
-    ts.sys.fileExists,
-    path.join('node_modules/', pkg.name, pkg.vetur.attributes)
-  );
+  const tagsPath = ts.findConfigFile(workspaceOrDependencyPath, ts.sys.fileExists, pkg.vetur.tags);
+  const attrsPath = ts.findConfigFile(workspaceOrDependencyPath, ts.sys.fileExists, pkg.vetur.attributes);
 
   try {
     if (tagsPath && attrsPath) {

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -113,12 +113,16 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
       settings['gridsome'] = true;
     }
 
+    if (packageJson['vetur']) {
+      const tagProvider = getRuntimeTagProvider(workspacePath, packageJson);
+      if (tagProvider) {
+        allTagProviders.push(tagProvider);
+      }
+    }
+
     for (const dep in dependencies) {
-      const runtimePkgPath = ts.findConfigFile(
-        workspacePath,
-        ts.sys.fileExists,
-        join('node_modules', dep, 'package.json')
-      );
+      const dependencyPath = join(workspacePath, 'node_modules', dep);
+      const runtimePkgPath = ts.findConfigFile(dependencyPath, ts.sys.fileExists, 'package.json');
 
       if (!runtimePkgPath) {
         continue;
@@ -129,7 +133,7 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
         continue;
       }
 
-      const tagProvider = getRuntimeTagProvider(workspacePath, runtimePkg);
+      const tagProvider = getRuntimeTagProvider(dependencyPath, runtimePkg);
       if (!tagProvider) {
         continue;
       }


### PR DESCRIPTION
Hi thanks for all your work!

Currently dependencies inside the `node_modules` folder may declare custom tags and attributes within their package.json's `vetur`-attribute. See https://github.com/vuejs/vetur/blob/master/docs/framework.md#custom-tags--attributes

This PR extends this feature to also support the package.json directly inside the workspace path.
This is especially useful, for global components and dependencies not declaring vetur tags.

