### PR TITLE
Fix a problem vetur show red underline errors in files whose names en…

### DIFF
--- a/client/commands/virtualFileCommand.ts
+++ b/client/commands/virtualFileCommand.ts
@@ -22,7 +22,7 @@ export async function registerVeturTextDocumentProviders() {
 
 export function generateShowVirtualFileCommand(client: LanguageClient) {
   return async () => {
-    if (!vscode.window.activeTextEditor || !vscode.window.activeTextEditor.document.fileName.endsWith('.vue')) {
+    if (!vscode.window.activeTextEditor || !vscode.window.activeTextEditor.document.fileName.toLowerCase().endsWith('.vue')) {
       return vscode.window.showInformationMessage(
         'Failed to show virtual file. Make sure the current file is a .vue file.'
       );

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -185,7 +185,7 @@ export async function getJavascriptMode(
               detail: entry.name + entry.kindModifiers
             };
           } else {
-            if (entry.name.endsWith('.vue')) {
+            if (entry.name.toLowerCase().endsWith('.vue')) {
               return {
                 label: entry.name.slice(0, -'.vue'.length),
                 detail: entry.name

--- a/server/src/modes/vue/snippets.ts
+++ b/server/src/modes/vue/snippets.ts
@@ -82,7 +82,7 @@ function loadAllSnippets(rootDir: string, source: SnippetSource): Snippet[] {
         return;
       }
       const absPath = path.resolve(rootDir, p);
-      if (!absPath.endsWith('.vue') && fs.existsSync(absPath) && fs.lstatSync(absPath).isDirectory()) {
+      if (!absPath.toLowerCase().endsWith('.vue') && fs.existsSync(absPath) && fs.lstatSync(absPath).isDirectory()) {
         const customDirSnippets = loadSnippetsFromDir(absPath, source, 'custom').map(s => {
           return {
             ...s,
@@ -107,7 +107,7 @@ function loadSnippetsFromDir(dir: string, source: SnippetSource, type: SnippetTy
 
   try {
     fs.readdirSync(dir)
-      .filter(p => p.endsWith('.vue'))
+      .filter(p => p.toLowerCase().endsWith('.vue'))
       .forEach(p => {
         snippets.push({
           source,

--- a/server/src/services/typescriptService/moduleResolutionCache.ts
+++ b/server/src/services/typescriptService/moduleResolutionCache.ts
@@ -9,9 +9,9 @@ export class ModuleResolutionCache {
 
   getCache(moduleName: string, containingFile: string): ts.ResolvedModule | undefined {
     if (!this._cache[containingFile]) {
-      if (containingFile.endsWith('.vue')) {
+      if (containingFile.toLowerCase().endsWith('.vue')) {
         this._cache[containingFile] = this._cache[containingFile + '.template'] = {};
-      } else if (containingFile.endsWith('.vue.template')) {
+      } else if (containingFile.toLowerCase().endsWith('.vue.template')) {
         this._cache[containingFile.slice(0, -'.template'.length)] = this._cache[containingFile] = {};
       } else {
         this._cache[containingFile] = {};
@@ -24,9 +24,9 @@ export class ModuleResolutionCache {
 
   setCache(moduleName: string, containingFile: string, cache: ts.ResolvedModule) {
     if (!this._cache[containingFile]) {
-      if (containingFile.endsWith('.vue')) {
+      if (containingFile.toLowerCase().endsWith('.vue')) {
         this._cache[containingFile] = this._cache[containingFile + '.template'] = {};
-      } else if (containingFile.endsWith('.vue.template')) {
+      } else if (containingFile.toLowerCase().endsWith('.vue.template')) {
         this._cache[containingFile.slice(0, -'.template'.length)] = this._cache[containingFile] = {};
       } else {
         this._cache[containingFile] = {};

--- a/server/src/services/typescriptService/serviceHost.ts
+++ b/server/src/services/typescriptService/serviceHost.ts
@@ -132,7 +132,7 @@ export function getServiceHost(
     const filePath = getFilePath(doc.uri);
     // When file is not in language service, add it
     if (!localScriptRegionDocuments.has(fileFsPath)) {
-      if (fileFsPath.endsWith('.vue') || fileFsPath.endsWith('.vue.template')) {
+      if (fileFsPath.toLowerCase().endsWith('.vue') || fileFsPath.toLowerCase().endsWith('.vue.template')) {
         scriptFileNameSet.add(filePath);
       }
     }
@@ -154,7 +154,7 @@ export function getServiceHost(
     const filePath = getFilePath(doc.uri);
     // When file is not in language service, add it
     if (!localScriptRegionDocuments.has(fileFsPath)) {
-      if (fileFsPath.endsWith('.vue') || fileFsPath.endsWith('.vue.template')) {
+      if (fileFsPath.toLowerCase().endsWith('.vue') || fileFsPath.toLowerCase().endsWith('.vue.template')) {
         scriptFileNameSet.add(filePath);
       }
     }
@@ -279,7 +279,7 @@ export function getServiceHost(
             return undefined;
           }
 
-          if (tsResolvedModule.resolvedFileName.endsWith('.vue.ts')) {
+          if (tsResolvedModule.resolvedFileName.toLowerCase().endsWith('.vue.ts')) {
             const resolvedFileName = tsResolvedModule.resolvedFileName.slice(0, -'.ts'.length);
             const uri = Uri.file(resolvedFileName);
             const resolvedFileFsPath = normalizeFileNameToFsPath(resolvedFileName);

--- a/server/src/services/typescriptService/test/sourceMap.test.ts
+++ b/server/src/services/typescriptService/test/sourceMap.test.ts
@@ -123,7 +123,7 @@ suite('Source Map generation', () => {
     const fixturePath = path.resolve(__dirname, repoRootPath, './test/interpolation/fixture/diagnostics');
 
     fs.readdirSync(fixturePath).forEach(file => {
-      if (file.endsWith('.vue')) {
+      if (file.toLowerCase().endsWith('.vue')) {
         const filePath = path.resolve(fixturePath, file);
         test(`Source Map generation for ${path.relative(repoRootPath, filePath)}`, () => {
           filePathToTest(filePath);

--- a/server/src/services/typescriptService/util.ts
+++ b/server/src/services/typescriptService/util.ts
@@ -1,5 +1,5 @@
 export function isVueFile(path: string) {
-  return path.endsWith('.vue');
+  return path.toLowerCase().endsWith('.vue');
 }
 
 /**
@@ -7,7 +7,7 @@ export function isVueFile(path: string) {
  * to be used in TS Language Service
  */
 export function isVirtualVueFile(path: string) {
-  return path.endsWith('.vue.ts') && !path.includes('node_modules');
+  return path.toLowerCase().endsWith('.vue.ts') && !path.includes('node_modules');
 }
 
 /**
@@ -15,5 +15,5 @@ export function isVirtualVueFile(path: string) {
  * pre-processed by Vetur to calculate template diagnostics in TS Language Service
  */
 export function isVirtualVueTemplateFile(path: string) {
-  return path.endsWith('.vue.template');
+  return path.toLowerCase().endsWith('.vue.template');
 }


### PR DESCRIPTION
…d with upper case like "Vue" or "VUE"

Currently, if the Vue file name extension is end with lower case letters "*.vue", everything is fine. But if it's end with upper case letters like "Vue" or "VUE", vetur will show red underline errors in these files. I add `.toLowerCase()` before all the `.endsWith` to fix this problem.