### PR TITLE
Update linting-error.md

### DIFF
--- a/docs/linting-error.md
+++ b/docs/linting-error.md
@@ -23,10 +23,7 @@ After you installed [ESLint plugin](https://marketplace.visualstudio.com/items?i
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    {
-      "language": "vue",
-      "autoFix": true
-    },
+    "vue"
   ]
 }
 ```


### PR DESCRIPTION
> Auto Fix is enabled by default. Use the single string form.

warning is shown due to changes in vscode-eslint.

![Screen Shot 2019-12-27 at 8 22 53 PM](https://user-images.githubusercontent.com/53117838/71537321-72b1cc80-28e8-11ea-8eaa-37edc4b13aa5.png)

As autoFix is set to `true` by default, object format in `eslint.validate` is now deprecated.
Check [vscode-eslint#7b5c40536131aa94eccd8a175e37104f5b785071](https://github.com/microsoft/vscode-eslint/commit/7b5c40536131aa94eccd8a175e37104f5b785071#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R223)