### PR TITLE
Fix Windows paths.

### DIFF
--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { getFileFsPath } from '../utils/paths';
 
 import {
   DidChangeConfigurationParams,
@@ -198,7 +199,7 @@ export class VLS {
 
       changes.forEach(c => {
         if (c.type === FileChangeType.Changed) {
-          const fsPath = Uri.parse(c.uri).fsPath;
+          const fsPath = getFileFsPath(c.uri);
           jsMode.onDocumentChanged!(fsPath);
         }
       });
@@ -349,8 +350,8 @@ export class VLS {
         if (this.workspacePath && ref[0] === '/') {
           return Uri.file(path.resolve(this.workspacePath, ref)).toString();
         }
-        const docUri = Uri.parse(doc.uri);
-        return Uri.file(path.resolve(docUri.fsPath, '..', ref)).toString();
+        const fsPath = getFileFsPath(doc.uri);
+        return Uri.file(path.resolve(fsPath, '..', ref)).toString();
       }
     };
 

--- a/server/src/utils/paths.ts
+++ b/server/src/utils/paths.ts
@@ -50,8 +50,10 @@ export function getFileFsPath(documentUri: string): string {
 export function getFilePath(documentUri: string): string {
   const IS_WINDOWS = platform() === 'win32';
   if (IS_WINDOWS) {
-    // Windows have a leading slash like /C:/Users/pine
-    return Uri.parse(documentUri).path.slice(1);
+	// Windows have a leading slash like /C:/Users/pine
+    // vscode-uri use lower-case drive letter
+    // https://github.com/microsoft/vscode-uri/blob/95e03c06f87d38f25eda1ae3c343fe5b7eec3f52/src/index.ts#L1017
+    return Uri.parse(documentUri).path.replace(/^\/[a-zA-Z]/, (s: string) => s.slice(1).toLowerCase());
   } else {
     return Uri.parse(documentUri).path;
   }

--- a/server/src/utils/paths.ts
+++ b/server/src/utils/paths.ts
@@ -50,7 +50,7 @@ export function getFileFsPath(documentUri: string): string {
 export function getFilePath(documentUri: string): string {
   const IS_WINDOWS = platform() === 'win32';
   if (IS_WINDOWS) {
-	// Windows have a leading slash like /C:/Users/pine
+    // Windows have a leading slash like /C:/Users/pine
     // vscode-uri use lower-case drive letter
     // https://github.com/microsoft/vscode-uri/blob/95e03c06f87d38f25eda1ae3c343fe5b7eec3f52/src/index.ts#L1017
     return Uri.parse(documentUri).path.replace(/^\/[a-zA-Z]/, (s: string) => s.slice(1).toLowerCase());


### PR DESCRIPTION
vscode-uri use lower-case drive-letter. So convert it always in getFilePath()

Fixes https://github.com/vuejs/vetur/issues/1316