### PR TITLE
Prevent linebreak in </template> from breaking syntax highlighting

### DIFF
--- a/syntaxes/vue-generated.json
+++ b/syntaxes/vue-generated.json
@@ -351,7 +351,7 @@
           "name": "entity.name.tag.template.html"
         }
       },
-      "end": "(</)(template)(>)",
+      "end": "^(</)(template)(>)",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -375,7 +375,7 @@
               "name": "punctuation.definition.tag.end.html"
             }
           },
-          "end": "(?=</template>)",
+          "end": "(?=^</template>)",
           "patterns": [
             {
               "include": "text.html.vue-html"

--- a/syntaxes/vue-html.YAML
+++ b/syntaxes/vue-html.YAML
@@ -54,7 +54,7 @@ patterns:
       - name: invalid.illegal.bad-comments-or-CDATA.html
         match: (\s*)(?!--|>)\S(\s*)
   - name: meta.tag.block.any.html
-    begin: (</?)((?i:template)[a-zA-Z0-9:-]+\b)
+    begin: (</?)([a-zA-Z0-9:-]+\b)
     beginCaptures:
       '1': { name: punctuation.definition.tag.begin.html }
       '2': { name: entity.name.tag.block.any.html }
@@ -63,33 +63,6 @@ patterns:
       '1': { name: punctuation.definition.tag.end.html }
     patterns:
       - include: '#tag-stuff'
-  - begin: (<)(template)\b(?=[^/>]*/>\s*$)
-    beginCaptures:
-      '1': { name: punctuation.definition.tag.begin.html }
-      '2': { name: entity.name.tag.style.html }
-    end: (/>)
-    endCaptures:
-      '1': { name: punctuation.definition.tag.end.html }
-    patterns:
-      - include: '#tag-stuff'
-  - begin: (<)(template)
-    beginCaptures:
-      '1': { name: punctuation.definition.tag.begin.html }
-      '2': { name: entity.name.tag.style.html }
-    end: (</)(template)(>)
-    endCaptures:
-      '1': { name: punctuation.definition.tag.begin.html }
-      '2': { name: entity.name.tag.style.html }
-      '3': { name: punctuation.definition.tag.end.html }
-    patterns:
-      - include: '#tag-stuff'
-      - contentName: text.html.vue-html
-        begin: (>)
-        beginCaptures:
-          '1': { name: punctuation.definition.tag.end.html }
-        end: (?=</template>)
-        patterns:
-          - include: text.html.vue-html
   - name: meta.tag.structure.any.html
     begin: (</?)((?i:body|head|html)\b)
     end: (>)

--- a/syntaxes/vue-html.tmLanguage.json
+++ b/syntaxes/vue-html.tmLanguage.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "meta.tag.block.any.html",
-      "begin": "(</?)((?i:template)[a-zA-Z0-9:-]+\\b)",
+      "begin": "(</?)([a-zA-Z0-9:-]+\\b)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -133,71 +133,6 @@
       "patterns": [
         {
           "include": "#tag-stuff"
-        }
-      ]
-    },
-    {
-      "begin": "(<)(template)\\b(?=[^/>]*/>\\s*$)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.begin.html"
-        },
-        "2": {
-          "name": "entity.name.tag.style.html"
-        }
-      },
-      "end": "(/>)",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.end.html"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#tag-stuff"
-        }
-      ]
-    },
-    {
-      "begin": "(<)(template)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.begin.html"
-        },
-        "2": {
-          "name": "entity.name.tag.style.html"
-        }
-      },
-      "end": "(</)(template)(>)",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.tag.begin.html"
-        },
-        "2": {
-          "name": "entity.name.tag.style.html"
-        },
-        "3": {
-          "name": "punctuation.definition.tag.end.html"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#tag-stuff"
-        },
-        {
-          "contentName": "text.html.vue-html",
-          "begin": "(>)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.tag.end.html"
-            }
-          },
-          "end": "(?=</template>)",
-          "patterns": [
-            {
-              "include": "text.html.vue-html"
-            }
-          ]
         }
       ]
     },

--- a/syntaxes/vue.tmLanguage.json
+++ b/syntaxes/vue.tmLanguage.json
@@ -265,7 +265,7 @@
           "name": "entity.name.tag.template.html"
         }
       },
-      "end": "(</)(template)(>)",
+      "end": "^(</)(template)(>)",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -289,7 +289,7 @@
               "name": "punctuation.definition.tag.end.html"
             }
           },
-          "end": "(?=</template>)",
+          "end": "(?=^</template>)",
           "patterns": [
             {
               "include": "text.html.vue-html"

--- a/syntaxes/vue.yaml
+++ b/syntaxes/vue.yaml
@@ -130,7 +130,7 @@ patterns:
     beginCaptures:
       '1': { name: punctuation.definition.tag.begin.html }
       '2': { name: entity.name.tag.template.html }
-    end: (</)(template)(>)
+    end: ^(</)(template)(>)
     endCaptures:
       '1': { name: punctuation.definition.tag.begin.html }
       '2': { name: entity.name.tag.template.html }
@@ -141,7 +141,7 @@ patterns:
         begin: (>)
         beginCaptures:
           '1': { name: punctuation.definition.tag.end.html }
-        end: (?=</template>)
+        end: (?=^</template>)
         patterns:
           - include: text.html.vue-html
 

--- a/test/grammar/fixture/TemplateTag.vue
+++ b/test/grammar/fixture/TemplateTag.vue
@@ -1,0 +1,11 @@
+<template>
+  <template
+    >Test</template
+  >
+</template>
+
+<script>
+export default {
+  
+}
+</script>

--- a/test/grammar/results/Html_vue.json
+++ b/test/grammar/results/Html_vue.json
@@ -2553,7 +2553,7 @@
 	},
 	{
 		"c": "<",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -2564,7 +2564,7 @@
 	},
 	{
 		"c": "router-link",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -2575,7 +2575,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2586,7 +2586,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2597,7 +2597,7 @@
 	},
 	{
 		"c": "to",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -2608,7 +2608,7 @@
 	},
 	{
 		"c": "=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2619,7 +2619,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2630,7 +2630,7 @@
 	},
 	{
 		"c": "{",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js punctuation.definition.block.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js punctuation.definition.block.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2641,7 +2641,7 @@
 	},
 	{
 		"c": "path",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js meta.object-literal.key.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js meta.object-literal.key.js",
 		"r": {
 			"dark_plus": "meta.object-literal.key: #9CDCFE",
 			"light_plus": "meta.object-literal.key: #001080",
@@ -2652,7 +2652,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js meta.object-literal.key.js punctuation.separator.key-value.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js meta.object-literal.key.js punctuation.separator.key-value.js",
 		"r": {
 			"dark_plus": "meta.object-literal.key: #9CDCFE",
 			"light_plus": "meta.object-literal.key: #001080",
@@ -2663,7 +2663,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2674,7 +2674,7 @@
 	},
 	{
 		"c": "`",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js punctuation.definition.string.template.begin.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js punctuation.definition.string.template.begin.js",
 		"r": {
 			"dark_plus": "string: #CE9178",
 			"light_plus": "string: #A31515",
@@ -2685,7 +2685,7 @@
 	},
 	{
 		"c": "/my/path#hash=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js",
 		"r": {
 			"dark_plus": "string: #CE9178",
 			"light_plus": "string: #A31515",
@@ -2696,7 +2696,7 @@
 	},
 	{
 		"c": "${",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js punctuation.definition.template-expression.begin.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js punctuation.definition.template-expression.begin.js",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.begin: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.begin: #0000FF",
@@ -2707,7 +2707,7 @@
 	},
 	{
 		"c": "hash",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js meta.embedded.line.js variable.other.readwrite.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js meta.embedded.line.js variable.other.readwrite.js",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
@@ -2718,7 +2718,7 @@
 	},
 	{
 		"c": "}",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js punctuation.definition.template-expression.end.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js meta.template.expression.js punctuation.definition.template-expression.end.js",
 		"r": {
 			"dark_plus": "punctuation.definition.template-expression.end: #569CD6",
 			"light_plus": "punctuation.definition.template-expression.end: #0000FF",
@@ -2729,7 +2729,7 @@
 	},
 	{
 		"c": "`",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js punctuation.definition.string.template.end.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js meta.object.member.js string.template.js punctuation.definition.string.template.end.js",
 		"r": {
 			"dark_plus": "string: #CE9178",
 			"light_plus": "string: #A31515",
@@ -2740,7 +2740,7 @@
 	},
 	{
 		"c": "}",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.objectliteral.js punctuation.definition.block.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.objectliteral.js punctuation.definition.block.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2751,7 +2751,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2762,7 +2762,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -2784,7 +2784,7 @@
 	},
 	{
 		"c": "</",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -2795,7 +2795,7 @@
 	},
 	{
 		"c": "router-link",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -2806,7 +2806,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -2861,7 +2861,7 @@
 	},
 	{
 		"c": "<",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -2872,7 +2872,7 @@
 	},
 	{
 		"c": "icon",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -2883,7 +2883,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2894,7 +2894,7 @@
 	},
 	{
 		"c": "v-if",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -2905,7 +2905,7 @@
 	},
 	{
 		"c": "=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2916,7 +2916,7 @@
 	},
 	{
 		"c": "foo",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2927,7 +2927,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2938,7 +2938,7 @@
 	},
 	{
 		"c": "bar",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -2949,7 +2949,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2960,7 +2960,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2971,7 +2971,7 @@
 	},
 	{
 		"c": "hover",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -2982,7 +2982,7 @@
 	},
 	{
 		"c": "=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2993,7 +2993,7 @@
 	},
 	{
 		"c": "bar",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -3003,8 +3003,8 @@
 		}
 	},
 	{
-		"c": " ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"c": " /",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -3014,8 +3014,8 @@
 		}
 	},
 	{
-		"c": "/>",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"c": ">",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",

--- a/test/grammar/results/Issue1465_vue.json
+++ b/test/grammar/results/Issue1465_vue.json
@@ -89,7 +89,7 @@
 	},
 	{
 		"c": "<",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -100,7 +100,7 @@
 	},
 	{
 		"c": "svg",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -111,7 +111,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -133,7 +133,7 @@
 	},
 	{
 		"c": "<",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -144,7 +144,7 @@
 	},
 	{
 		"c": "line",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -155,7 +155,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -166,7 +166,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -177,7 +177,7 @@
 	},
 	{
 		"c": "x1",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -188,7 +188,7 @@
 	},
 	{
 		"c": "=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -199,7 +199,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -210,7 +210,7 @@
 	},
 	{
 		"c": "line",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue variable.other.object.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue variable.other.object.js",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
@@ -221,7 +221,7 @@
 	},
 	{
 		"c": ".",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.accessor.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.accessor.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -232,7 +232,7 @@
 	},
 	{
 		"c": "start",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue variable.other.property.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue variable.other.property.js",
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
@@ -243,7 +243,7 @@
 	},
 	{
 		"c": "[",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.array.literal.js meta.brace.square.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.array.literal.js meta.brace.square.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -254,7 +254,7 @@
 	},
 	{
 		"c": "0",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.array.literal.js constant.numeric.decimal.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.array.literal.js constant.numeric.decimal.js",
 		"r": {
 			"dark_plus": "constant.numeric: #B5CEA8",
 			"light_plus": "constant.numeric: #09885A",
@@ -265,7 +265,7 @@
 	},
 	{
 		"c": "]",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue meta.array.literal.js meta.brace.square.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.array.literal.js meta.brace.square.js",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -276,7 +276,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -287,7 +287,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -298,7 +298,7 @@
 	},
 	{
 		"c": ":",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -309,7 +309,7 @@
 	},
 	{
 		"c": "y1",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue entity.other.attribute-name.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -320,7 +320,7 @@
 	},
 	{
 		"c": "=",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue punctuation.separator.key-value.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -331,7 +331,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.begin.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -342,7 +342,7 @@
 	},
 	{
 		"c": "true",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue constant.language.boolean.true.js",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue constant.language.boolean.true.js",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -353,7 +353,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "source.vue text.html.vue-html meta.tag.other.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue punctuation.definition.string.end.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -364,7 +364,7 @@
 	},
 	{
 		"c": "      ",
-		"t": "source.vue text.html.vue-html meta.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -375,7 +375,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -386,7 +386,7 @@
 	},
 	{
 		"c": "</",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -397,7 +397,7 @@
 	},
 	{
 		"c": "line",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -408,7 +408,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -430,7 +430,7 @@
 	},
 	{
 		"c": "</",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.begin.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",
@@ -441,7 +441,7 @@
 	},
 	{
 		"c": "svg",
-		"t": "source.vue text.html.vue-html meta.tag.other.html entity.name.tag.other.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
 		"r": {
 			"dark_plus": "entity.name.tag: #569CD6",
 			"light_plus": "entity.name.tag: #800000",
@@ -452,7 +452,7 @@
 	},
 	{
 		"c": ">",
-		"t": "source.vue text.html.vue-html meta.tag.other.html punctuation.definition.tag.end.html",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
 		"r": {
 			"dark_plus": "punctuation.definition.tag: #808080",
 			"light_plus": "punctuation.definition.tag: #800000",

--- a/test/grammar/results/Issue1465_vue.json
+++ b/test/grammar/results/Issue1465_vue.json
@@ -257,9 +257,9 @@
 		"t": "source.vue text.html.vue-html meta.tag.block.any.html meta.directive.vue source.directive.vue meta.array.literal.js constant.numeric.decimal.js",
 		"r": {
 			"dark_plus": "constant.numeric: #B5CEA8",
-			"light_plus": "constant.numeric: #09885A",
+			"light_plus": "constant.numeric: #098658",
 			"dark_vs": "constant.numeric: #B5CEA8",
-			"light_vs": "constant.numeric: #09885A",
+			"light_vs": "constant.numeric: #098658",
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},

--- a/test/grammar/results/TemplateTag_vue.json
+++ b/test/grammar/results/TemplateTag_vue.json
@@ -1,0 +1,321 @@
+[
+	{
+		"c": "<",
+		"t": "source.vue punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "template",
+		"t": "source.vue entity.name.tag.template.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "  ",
+		"t": "source.vue text.html.vue-html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "<",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "template",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "Test",
+		"t": "source.vue text.html.vue-html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "</",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "template",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html entity.name.tag.block.any.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": "  ",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue text.html.vue-html meta.tag.block.any.html punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "</",
+		"t": "source.vue punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "template",
+		"t": "source.vue entity.name.tag.template.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "<",
+		"t": "source.vue punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "script",
+		"t": "source.vue entity.name.tag.script.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "export",
+		"t": "source.vue source.js meta.export.default.js keyword.control.export.js",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.vue source.js meta.export.default.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "default",
+		"t": "source.vue source.js meta.export.default.js keyword.control.default.js",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.vue source.js meta.export.default.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "source.vue source.js meta.export.default.js meta.objectliteral.js punctuation.definition.block.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "  ",
+		"t": "source.vue source.js meta.export.default.js meta.objectliteral.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.vue source.js meta.export.default.js meta.objectliteral.js punctuation.definition.block.js",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "</",
+		"t": "source.vue punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "script",
+		"t": "source.vue entity.name.tag.script.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "source.vue punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	}
+]


### PR DESCRIPTION
End the vue-html only with a `</template>` at the beginning of a line.
Because the `<template>` tag starts a grammar in source.vue files and
can also be used a a tag *within* that grammar, the closing
`</template>` of the grammar must be distinguishable from the same
closing tag within the vue-html grammar.

This enables removing the recursive application of the vue-html grammar
within the vue-html grammar because source.vue can reliably know when
a `</template>` should end the grammar.

* New restriction: there can be only 1 closing `</template>` within a
  Vue single-file component (SFC) otherwise the vue-html grammar will
  be closed early. That closing `</template>` must also appear at the
  beginning of a line. Because this follows Vue formatting guidelines,
  this should have zero impact on users who following those guidelines.

Fixes #1211