### PR TITLE
Fixes errors when no initialization options are given to vue-language-server

### DIFF
--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -129,10 +129,13 @@ export class VLS {
 
   private setupConfigListeners() {
     this.lspConnection.onDidChangeConfiguration(async ({ settings }: DidChangeConfigurationParams) => {
-      this.configure(settings);
 
-      // onDidChangeConfiguration will fire for Language Server startup
-      await this.setupDynamicFormatters(settings);
+      if (settings) {
+        this.configure(settings);
+
+        // onDidChangeConfiguration will fire for Language Server startup
+        await this.setupDynamicFormatters(settings);
+      }
     });
 
     this.documentService.getAllDocuments().forEach(this.triggerValidation);

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -83,7 +83,7 @@ export class VLS {
   }
 
   async init(params: InitializeParams) {
-    const config: VLSFullConfig = params.initializationOptions.config
+    const config: VLSFullConfig = params.initializationOptions?.config
       ? _.merge(getDefaultVLSConfig(), params.initializationOptions.config)
       : getDefaultVLSConfig();
 
@@ -106,7 +106,9 @@ export class VLS {
         infoService: this.vueInfoService,
         dependencyService: this.dependencyService
       },
-      params.initializationOptions['globalSnippetDir']
+      params.initializationOptions
+        ? params.initializationOptions['globalSnippetDir']
+        : undefined
     );
 
     this.setupConfigListeners();


### PR DESCRIPTION
This solves #977 and builds upon the work of #1634 

Without this fixes I wasn't able to initialize the server for Emacs Eglot without errors, it should solve the same issues on other clients.

Notice I'm using the "optional chaining operator" on the `VLSFullConfig` assignation (given that this project uses Babel).