### PR TITLE
Fix missing module error 'vscode-css-languageservice/lib/umd/data/browsers

### DIFF
--- a/server/src/modes/style/stylus/css-browser-data.ts
+++ b/server/src/modes/style/stylus/css-browser-data.ts
@@ -18,7 +18,7 @@ export interface LoadedCSSData {
   pseudoElements: IPseudoElementData[];
 }
 
-const rawData: CSSDataV1 = require('vscode-css-languageservice/lib/umd/data/browsers').cssData;
+const rawData: CSSDataV1 = require('vscode-css-languageservice/lib/umd/data/webCustomData').cssData;
 
 export const cssData: LoadedCSSData = {
   properties: rawData.properties || [],


### PR DESCRIPTION
File `vscode-css-languageservice/src/data/browsers.ts` was renamed to `vscode-css-languageservice/src/data/webCustomData.ts` in vscode-css-languageservice v4.1.0