### PR TITLE
Subfolders support

### DIFF
--- a/server/src/utils/paths.ts
+++ b/server/src/utils/paths.ts
@@ -57,6 +57,15 @@ export function getFilePath(documentUri: string): string {
   }
 }
 
+export function getDirectoryName(fsPath: string) {
+  const lastSlashIndex = fsPath.lastIndexOf('/');
+  if (lastSlashIndex < 1) {
+    // Impossible or root
+    return fsPath;
+  }
+  return fsPath.slice(0, lastSlashIndex);
+}
+
 export function normalizeFileNameToFsPath(fileName: string) {
   return Uri.file(fileName).fsPath;
 }

--- a/test/lsp/diagnostics/helper.ts
+++ b/test/lsp/diagnostics/helper.ts
@@ -3,7 +3,11 @@ import * as assert from 'assert';
 import { sleep } from '../helper';
 import * as _ from 'lodash';
 
-export async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: vscode.Diagnostic[]) {
+export async function testDiagnostics(
+  docUri: vscode.Uri,
+  expectedDiagnostics: vscode.Diagnostic[],
+  unexpectedDiagnostics: vscode.Diagnostic[] = []
+) {
   // For diagnostics to show up
   await sleep(2000);
 
@@ -15,6 +19,16 @@ export async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: v
         return isEqualDiagnostic(ed, d);
       }),
       `Cannot find matching diagnostics for ${ed.message}\n${JSON.stringify(ed)}\n` +
+        `Seen diagnostics are:\n${JSON.stringify(result)}`
+    );
+  });
+
+  unexpectedDiagnostics.forEach(ed => {
+    assert.ok(
+      result.every(d => {
+        return !isEqualDiagnostic(ed, d);
+      }),
+      `Found unexpected matching diagnostics for ${ed.message}\n${JSON.stringify(ed)}\n` +
         `Seen diagnostics are:\n${JSON.stringify(result)}`
     );
   });

--- a/test/lsp/diagnostics/neasted-config.test.ts
+++ b/test/lsp/diagnostics/neasted-config.test.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../helper';
+import { sameLineRange, getDocUri } from '../util';
+import { testDiagnostics } from './helper';
+
+describe('Should find correct diagnostics for sub folders with local `tsconfig.json`', () => {
+  const docUri = getDocUri('client/diagnostics/custom-config/Switch.vue');
+
+  before('activate', async () => {
+    await activateLS();
+    await showFile(docUri);
+    await sleep(FILE_LOAD_SLEEP_TIME);
+  });
+
+  it('shows diagnostic errors for <script> region', async () => {
+    const expectedDiagnostics: vscode.Diagnostic[] = [
+      {
+        range: sameLineRange(9, 2, 6),
+        severity: vscode.DiagnosticSeverity.Error,
+        message: 'Fallthrough case in switch.',
+        code: 7029
+      },
+      {
+        range: sameLineRange(6, 18, 30),
+        severity: vscode.DiagnosticSeverity.Error,
+        message: "Cannot find module '@/notFound'."
+      }
+    ];
+
+    const unexpectedDiagnostics: vscode.Diagnostic[] = [
+      {
+        range: sameLineRange(5, 19, 29),
+        severity: vscode.DiagnosticSeverity.Error,
+        message: "Cannot find module '@/logger'."
+      }
+    ];
+
+    await testDiagnostics(docUri, expectedDiagnostics, unexpectedDiagnostics);
+  });
+});

--- a/test/lsp/fixture/client/diagnostics/custom-config/Switch.vue
+++ b/test/lsp/fixture/client/diagnostics/custom-config/Switch.vue
@@ -1,0 +1,16 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+import logger from '@/logger';
+import other from '@/notFound';
+
+switch (Math.random() * 3) {
+  case 1:
+    logger.info('1');
+  case 2:
+    logger.info('2');
+    break;
+}
+</script>

--- a/test/lsp/fixture/client/diagnostics/custom-config/src/logger.ts
+++ b/test/lsp/fixture/client/diagnostics/custom-config/src/logger.ts
@@ -1,0 +1,1 @@
+export default console;

--- a/test/lsp/fixture/client/diagnostics/custom-config/tsconfig.json
+++ b/test/lsp/fixture/client/diagnostics/custom-config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "src/*.ts",
+    "*.ts"
+  ]
+}


### PR DESCRIPTION
Support for different configurations in subfolders #815 #385 (with aliases support). Not tested with multi-root projets.

## Example

https://github.com/Minigugus/vetur/blob/da24540a53d3d1982d233e18dcc5bdbbf8903ff5/test/lsp/fixture/client/diagnostics/custom-config/tsconfig.json#L3-L7

https://github.com/Minigugus/vetur/blob/da24540a53d3d1982d233e18dcc5bdbbf8903ff5/test/lsp/fixture/client/diagnostics/custom-config/Switch.vue

## How it works

For each directory with files opened by Vetur, if it is not cached, created 2 `LanguageService` (`js` and `template`) for that directory and then use thoses `LanguageService` for errors diagnostics. The `tsconfig.json`/`jsconfig.json` is resolved to its base directory (`"baseUrl": "."` works).

## Opportunities for improvement

Currently, the root `tsconfig.json` is still used and merged with local `tsconfig.json` (does not require `extends`).

This solution is not really optimized but I hope it will help.

*Even though the `CONTRIBUTING.MD` file requested it, I have not opened an issue to discuss the details of the implementation because the code is already written. If you think I was wrong, fill free to close this PR.*