### PR TITLE
[WIP] feat(completion): improve auto complete in html template

### DIFF
--- a/server/src/modes/template/services/vueInterpolationCompletion.ts
+++ b/server/src/modes/template/services/vueInterpolationCompletion.ts
@@ -1,63 +1,140 @@
-import { CompletionList, CompletionItemKind } from 'vscode-languageserver';
-import { VueFileInfo } from '../../../services/vueInfoService';
+import { CompletionList, CompletionItemKind, CompletionItem } from 'vscode-languageserver';
+import { VueFileInfo, DataInfo, MemberInfo } from '../../../services/vueInfoService';
+import { T_TypeScript } from '../../../services/dependencyService';
 
-export function doVueInterpolationComplete(vueFileInfo: VueFileInfo): CompletionList {
+import {} from 'vscode-languageclient';
+
+export function doVueInterpolationComplete(vueFileInfo: VueFileInfo, tsModule?: T_TypeScript): CompletionList {
   const result: CompletionList = {
     isIncomplete: false,
     items: []
   };
 
   if (vueFileInfo.componentInfo.props) {
-    vueFileInfo.componentInfo.props.forEach(p => {
-      result.items.push({
-        label: p.name,
-        documentation: {
-          kind: 'markdown',
-          value: p.documentation || `\`${p.name}\` prop`
-        },
-        kind: CompletionItemKind.Property
-      });
-    });
+    // vueFileInfo.componentInfo.props.forEach(p => {
+    //   result.items.push({
+    //     label: p.name,
+    //     documentation: {
+    //       kind: 'markdown',
+    //       value: p.documentation || `\`${p.name}\` prop`
+    //     },
+    //     kind: CompletionItemKind.Property
+    //   });
+    // });
+    result.items.push(...getCompletionItems(vueFileInfo.componentInfo.props, 'prop'));
   }
 
   if (vueFileInfo.componentInfo.data) {
-    vueFileInfo.componentInfo.data.forEach(p => {
-      result.items.push({
-        label: p.name,
-        documentation: {
-          kind: 'markdown',
-          value: p.documentation || `\`${p.name}\` data`
-        },
-        kind: CompletionItemKind.Property
-      });
-    });
+    // const v = tsModule?.textSpanEnd({} as any);
+
+    // tsModule.transpile(vueFileInfo.componentInfo.data[0].documentation)
+    // tsModule.create
+    // vueFileInfo.componentInfo.data.forEach(p => {
+    //   result.items.push(
+    //     ...[
+    //       {
+    //         label: p.name,
+    //         documentation: {
+    //           kind: 'markdown',
+    //           value: p.documentation || `\`${p.name}\` data`
+    //         },
+    //         kind: CompletionItemKind.Property
+    //       }
+    //     ]
+    //   );
+    // });
+
+    // for (const d of vueFileInfo.componentInfo.data) {
+    //   result.items.push({
+    //     label: d.name,
+    //     documentation: {
+    //       kind: 'markdown',
+    //       value: d.documentation || `\`${d.name}\` data`
+    //     },
+    //     kind: d.kind || CompletionItemKind.Property
+    //   });
+
+    //   for (const m of d.members) {
+    //     result.items.push({
+    //       label: `${d.name}.${m.name}`,
+    //       documentation: {
+    //         kind: 'markdown',
+    //         value: m.documentation || `\`${m.name}\` data`
+    //       },
+    //       kind: m.kind || CompletionItemKind.Property
+    //     });
+    //   }
+    // }
+
+    result.items.push(...getCompletionItems(vueFileInfo.componentInfo.data, 'data'));
   }
 
   if (vueFileInfo.componentInfo.computed) {
-    vueFileInfo.componentInfo.computed.forEach(p => {
-      result.items.push({
-        label: p.name,
-        documentation: {
-          kind: 'markdown',
-          value: p.documentation || `\`${p.name}\` computed`
-        },
-        kind: CompletionItemKind.Property
-      });
-    });
+    // vueFileInfo.componentInfo.computed.forEach(p => {
+    //   result.items.push({
+    //     label: p.name,
+    //     documentation: {
+    //       kind: 'markdown',
+    //       value: p.documentation || `\`${p.name}\` computed`
+    //     },
+    //     kind: CompletionItemKind.Property
+    //   });
+    // });
+    result.items.push(...getCompletionItems(vueFileInfo.componentInfo.computed, 'computed'));
   }
 
   if (vueFileInfo.componentInfo.methods) {
-    vueFileInfo.componentInfo.methods.forEach(p => {
-      result.items.push({
-        label: p.name,
-        documentation: {
-          kind: 'markdown',
-          value: p.documentation || `\`${p.name}\` method`
-        },
-        kind: CompletionItemKind.Method
-      });
-    });
+    // vueFileInfo.componentInfo.methods.forEach(p => {
+    //   result.items.push({
+    //     label: p.name,
+    //     documentation: {
+    //       kind: 'markdown',
+    //       value: p.documentation || `\`${p.name}\` method`
+    //     },
+    //     kind: CompletionItemKind.Method
+    //   });
+    // });
+    result.items.push(...getCompletionItems(vueFileInfo.componentInfo.methods, 'method'));
   }
 
   return result;
+}
+
+function* getCompletionItems(
+  items: MemberInfo[],
+  documentationType: string,
+  parentLabel = ''
+): Generator<CompletionItem> {
+  for (let i = 0; i < items.length; i++) {
+    const data = items[i];
+    const label = !!parentLabel ? `${parentLabel}.${data.name}` : data.name;
+
+    yield {
+      label,
+      documentation: {
+        kind: 'markdown',
+        value: data.documentation || `\`${data.name}\` ${documentationType}`
+      },
+      kind: data.kind || CompletionItemKind.Property
+    };
+
+    if (data.members) {
+      yield* getCompletionItems(data.members, documentationType, label);
+    }
+  }
+
+  // yield {
+  //   label,
+  //   documentation: {
+  //     kind: 'markdown',
+  //     value: data.documentation || `\`${data.name}\` ${documentationType}`
+  //   },
+  //   kind: data.kind || CompletionItemKind.Property
+  // } as CompletionItem;
+
+  // for (let i = 0; i < data.members.length; i++) {
+  //   const info = data.members[i];
+
+  //   yield* getCompletionItems(info, documentationType, label);
+  // }
 }

--- a/server/src/services/vueInfoService.ts
+++ b/server/src/services/vueInfoService.ts
@@ -1,6 +1,6 @@
 import { TextDocument } from 'vscode-languageserver';
 import { getFileFsPath } from '../utils/paths';
-import { Definition } from 'vscode-languageserver-types';
+import { Definition, CompletionItemKind } from 'vscode-languageserver-types';
 import { LanguageModes } from '../embeddedSupport/languageModes';
 
 /**
@@ -43,22 +43,18 @@ export interface ChildComponent {
   info?: VueFileInfo;
 }
 
-export interface PropInfo {
+export interface MemberInfo {
   name: string;
   documentation?: string;
+
+  members?: DataInfo[];
+  kind?: CompletionItemKind;
 }
-export interface DataInfo {
-  name: string;
-  documentation?: string;
-}
-export interface ComputedInfo {
-  name: string;
-  documentation?: string;
-}
-export interface MethodInfo {
-  name: string;
-  documentation?: string;
-}
+
+export interface PropInfo extends MemberInfo {}
+export interface DataInfo extends MemberInfo {}
+export interface ComputedInfo extends MemberInfo {}
+export interface MethodInfo extends MemberInfo {}
 
 export class VueInfoService {
   private languageModes: LanguageModes;


### PR DESCRIPTION
Improving auto completion on html, based on the component definition.

## Implemented
- [x] Provide deep member properties

## TODO 
- [ ] Support auto-completion when is expression




![image](https://user-images.githubusercontent.com/4620458/75449102-5243d400-5964-11ea-90fc-4d131d850198.png)

![image](https://user-images.githubusercontent.com/4620458/75449154-625bb380-5964-11ea-86c0-defeb2cab774.png)
![image](https://user-images.githubusercontent.com/4620458/75449179-6ee00c00-5964-11ea-87d6-9dbe8587d6f5.png)

![image](https://user-images.githubusercontent.com/4620458/75449192-769fb080-5964-11ea-973a-9bbe71573dca.png)


example:
```vue
<template>
  <div>
    <p v-if="obj.ourdata"></p>
  </div>
</template>

<script>
import { defineComponent } from "@vue/composition-api";

export default defineComponent({
  data() {
    return {
      mydata: "1",
      obj: {
        ourdata: 2,
        supa: {
          a: "a",
          n: 1122
        }
      }
    };
  },
  computed: {
    test() {
      return 1;
    },
    testObj() {
      return {
        a: 1,
        bb: {
          a: "2"
        }
      };
    }
  }
});
</script>
```

