### PR TITLE
fix(#1711) Get workspace typescript with the tsdk path (yarn@berry compat)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,3 +96,4 @@ Now you'll find `vetur-{version}.vsix`, you can install it by editor command "In
 ## Vetur uses different version of TypeScript in .vue files to what I installed in `node_modules`.
 
 You can enable `Vetur: Use Workspace Dependencies` setting so that it uses the same version of TypeScript in your workspace.
+NB: It will use `typescript.tsdk` setting as the path to look for if defined, defaulting to `node_modules/typescript`. This enables tools like Yarn PnP to set their own custom resolver.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -124,6 +124,7 @@ export function getDefaultVLSConfig(): VLSFullConfig {
       format: {}
     },
     typescript: {
+      tsdk: null,
       format: {}
     },
     emmet: {},

--- a/server/src/services/dependencyService.ts
+++ b/server/src/services/dependencyService.ts
@@ -54,7 +54,7 @@ export class DependencyService {
 
   constructor() {}
 
-  async init(workspacePath: string, useWorkspaceDependencies: boolean) {
+  async init(workspacePath: string, useWorkspaceDependencies: boolean, tsSDKPath: string) {
     if (!useWorkspaceDependencies) {
       const tsModule = await import('typescript');
       console.log(`Loaded bundled typescript@${tsModule.version}.`);
@@ -67,7 +67,7 @@ export class DependencyService {
         module: tsModule
       };
     } else {
-      const workspaceTSPath = path.resolve(workspacePath, 'node_modules/typescript');
+      const workspaceTSPath = path.resolve(workspacePath, tsSDKPath || 'node_modules/typescript');
       let tsModule: T_TypeScript;
       let bundled = false;
       try {

--- a/server/src/services/dependencyService.ts
+++ b/server/src/services/dependencyService.ts
@@ -67,7 +67,8 @@ export class DependencyService {
         module: tsModule
       };
     } else {
-      const workspaceTSPath = path.resolve(workspacePath, tsSDKPath || 'node_modules/typescript');
+      const tsPath = tsSDKPath && path.join(tsSDKPath, '..');
+      const workspaceTSPath = path.resolve(workspacePath, tsPath || 'node_modules/typescript');
       let tsModule: T_TypeScript;
       let bundled = false;
       try {

--- a/server/src/services/dependencyService.ts
+++ b/server/src/services/dependencyService.ts
@@ -54,7 +54,7 @@ export class DependencyService {
 
   constructor() {}
 
-  async init(workspacePath: string, useWorkspaceDependencies: boolean, tsSDKPath: string) {
+  async init(workspacePath: string, useWorkspaceDependencies: boolean, tsSDKPath?: string) {
     if (!useWorkspaceDependencies) {
       const tsModule = await import('typescript');
       console.log(`Loaded bundled typescript@${tsModule.version}.`);
@@ -67,17 +67,25 @@ export class DependencyService {
         module: tsModule
       };
     } else {
-      const tsPath = tsSDKPath && path.join(tsSDKPath, '..');
-      const workspaceTSPath = path.resolve(workspacePath, tsPath || 'node_modules/typescript');
+      let workspaceTSPath = path.resolve(workspacePath, 'node_modules/typescript');
+
+      if (tsSDKPath) {
+        if (path.isAbsolute(tsSDKPath)) {
+          workspaceTSPath = path.resolve(tsSDKPath, '..');
+        } else {
+          workspaceTSPath = path.resolve(workspacePath, tsSDKPath, '..');
+        }
+      }
+
       let tsModule: T_TypeScript;
       let bundled = false;
       try {
         tsModule = await import(workspaceTSPath);
-        console.log(`Loaded typescript@${tsModule.version} from workspace.`);
+        console.log(`Loaded typescript@${tsModule.version} from ${workspaceTSPath}.`);
       } catch (err) {
         tsModule = await import('typescript');
         bundled = true;
-        console.log(`Failed to load typescript from workspace. Using bundled typescript@${tsModule.version}.`);
+        console.log(`Failed to load typescript from ${workspaceTSPath}. Using bundled typescript@${tsModule.version}.`);
       }
 
       this.dependencies.typescript = {

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -104,7 +104,7 @@ export class VLS {
     this.workspacePath = workspacePath;
 
     await this.vueInfoService.init(this.languageModes);
-    await this.dependencyService.init(workspacePath, config.vetur.useWorkspaceDependencies);
+    await this.dependencyService.init(workspacePath, config.vetur.useWorkspaceDependencies, config.typescript.tsdk);
 
     await this.languageModes.init(
       workspacePath,


### PR DESCRIPTION
Naive attempt (proof of concept) to fetch TS runtime based on the `vscode.typescript.tsdk` setting with a fallback to `node_modules`. This will allow to use yarn@berry patched TS runtime as stated in #1711
I'd like to get some feedback/help to finalize this PR