### PR TITLE
Fix template interpolation in vfor when readonly array

### DIFF
--- a/server/src/services/typescriptService/bridge.ts
+++ b/server/src/services/typescriptService/bridge.ts
@@ -28,7 +28,7 @@ export declare const ${componentHelperName}: {
   ): any;
 };
 export declare const ${iterationHelperName}: {
-  <T>(list: T[], fn: (value: T, index: number) => any): any;
+  <T>(list: readonly T[], fn: (value: T, index: number) => any): any;
   <T>(obj: { [key: string]: T }, fn: (value: T, key: string, index: number) => any): any;
   (num: number, fn: (value: number) => any): any;
   <T>(obj: object, fn: (value: any, key: string, index: number) => any): any;

--- a/test/interpolation/fixture/hover/Basic.vue
+++ b/test/interpolation/fixture/hover/Basic.vue
@@ -7,6 +7,11 @@
         {{ item }}
       </li>
     </ul>
+    <ul>
+      <li v-for="(item, i) in readonlyList" :key="i">
+        {{ item }}
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -15,7 +20,8 @@ export default {
   data () {
     return {
       msg: 'Vetur means "Winter" in icelandic.',
-      list: [0, 1, 2]
+      list: [0, 1, 2],
+      readonlyList: ['foo', 'bar'] as Readonly<string[]>
     }
   }
 }

--- a/test/interpolation/hover/basic.test.ts
+++ b/test/interpolation/hover/basic.test.ts
@@ -25,6 +25,13 @@ describe('Should do hover interpolation for <template>', () => {
       range: sameLineRange(5, 18, 22)
     });
   });
+
+  it('shows hover for v-for variable on readonly array', async () => {
+    await testHover(docUri, position(10, 20), {
+      contents: ['\n```ts\n(parameter) item: string\n```\n'],
+      range: sameLineRange(10, 18, 22)
+    });
+  });
 });
 
 async function testHover(docUri: vscode.Uri, position: vscode.Position, expectedHover: vscode.Hover) {


### PR DESCRIPTION
When array is readonly, I will get `any` in `v-for` element.