### PR TITLE
Speed up and stabilize e2e test

### DIFF
--- a/client/vueMain.ts
+++ b/client/vueMain.ts
@@ -63,7 +63,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const client = initializeLanguageClient(serverModule, globalSnippetDir);
   context.subscriptions.push(client.start());
 
-  client
+  const promise = client
     .onReady()
     .then(() => {
       registerCustomClientNotificationHandlers(client);
@@ -72,6 +72,14 @@ export async function activate(context: vscode.ExtensionContext) {
     .catch(e => {
       console.log('Client initialization failed');
     });
+
+  return vscode.window.withProgress(
+    {
+      title: 'Vetur initialization',
+      location: vscode.ProgressLocation.Window
+    },
+    () => promise
+  );
 }
 
 function registerCustomClientNotificationHandlers(client: LanguageClient) {

--- a/test/interpolation/completion/basic.test.ts
+++ b/test/interpolation/completion/basic.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../lsp/helper';
+import { activateLS, showFile } from '../../lsp/helper';
 import { position, getDocUri } from '../util';
 import { testCompletion, testNoSuchCompletion } from './helper';
 import { CompletionItem, CompletionItemKind, MarkdownString } from 'vscode';
@@ -10,7 +10,6 @@ describe('Should autocomplete interpolation for <template>', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(templateDocUri);
-    await sleep(FILE_LOAD_SLEEP_TIME * 2);
   });
 
   const defaultList: CompletionItem[] = [

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { activateLS, showFile, FILE_LOAD_SLEEP_TIME } from '../helper';
-import { getDocUri, sleep, sameLineRange } from '../util';
+import { activateLS, showFile } from '../helper';
+import { getDocUri, sameLineRange } from '../util';
 import { testDiagnostics, testNoDiagnostics } from './helper';
 
 describe('Should find template-diagnostics in <template> region', () => {
@@ -255,7 +255,6 @@ describe('Should find template-diagnostics in <template> region', () => {
     it(`Shows no template diagnostics error for ${t}`, async () => {
       const docUri = getDocUri(`diagnostics/${t}`);
       await showFile(docUri);
-      await sleep(FILE_LOAD_SLEEP_TIME);
       await testNoDiagnostics(docUri);
     });
   });

--- a/test/interpolation/diagnostics/basic.test.ts
+++ b/test/interpolation/diagnostics/basic.test.ts
@@ -245,7 +245,6 @@ describe('Should find template-diagnostics in <template> region', () => {
     it(`Shows template diagnostics for ${t.file}`, async () => {
       const docUri = getDocUri(`diagnostics/${t.file}`);
       await showFile(docUri);
-      await sleep(FILE_LOAD_SLEEP_TIME);
       await testDiagnostics(docUri, t.diagnostics, !!t.skipSameDiagnosticCountAssert);
     });
   });

--- a/test/interpolation/diagnostics/helper.ts
+++ b/test/interpolation/diagnostics/helper.ts
@@ -2,16 +2,14 @@ import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as _ from 'lodash';
 import { sleep } from '../util';
+import { getDiagnosticsAndTimeout } from '../helper';
 
 export async function testDiagnostics(
   docUri: vscode.Uri,
   expectedDiagnostics: vscode.Diagnostic[],
   skipSameDiagnosticCountAssert: boolean
 ) {
-  // For diagnostics to show up
-  await sleep(2000);
-
-  const result = vscode.languages.getDiagnostics(docUri);
+  const result = await getDiagnosticsAndTimeout(docUri);
 
   if (!skipSameDiagnosticCountAssert) {
     assert.equal(

--- a/test/interpolation/diagnostics/helper.ts
+++ b/test/interpolation/diagnostics/helper.ts
@@ -51,7 +51,7 @@ export async function testDiagnostics(
 
 export async function testNoDiagnostics(docUri: vscode.Uri) {
   // For diagnostics to show up
-  await sleep(2000);
+  await sleep(3500);
 
   const result = vscode.languages.getDiagnostics(docUri);
 

--- a/test/interpolation/helper.ts
+++ b/test/interpolation/helper.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { sleep } from './util';
+import { performance } from 'perf_hooks';
 
 export const EXT_IDENTIFIER = 'octref.vetur';
 export const FILE_LOAD_SLEEP_TIME = 1500;
@@ -40,4 +42,18 @@ export function readFileAsync(path: string) {
       resolve(data);
     });
   });
+}
+
+// Retry to get diagnostics until length > 0 or timeout
+export async function getDiagnosticsAndTimeout(docUri: vscode.Uri, timeout = 5000) {
+  const startTime = performance.now();
+
+  let result = vscode.languages.getDiagnostics(docUri);
+
+  while (result.length <= 0 && startTime + timeout > performance.now()) {
+    result = vscode.languages.getDiagnostics(docUri);
+    await sleep(100);
+  }
+
+  return result;
 }

--- a/test/interpolation/hover/basic.test.ts
+++ b/test/interpolation/hover/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../lsp/helper';
+import { activateLS, showFile } from '../../lsp/helper';
 import { position, sameLineRange, getDocUri } from '../util';
 
 describe('Should do hover interpolation for <template>', () => {
@@ -9,7 +9,6 @@ describe('Should do hover interpolation for <template>', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows hover for msg in mustache', async () => {

--- a/test/lsp/features/codeAction/basic.test.ts
+++ b/test/lsp/features/codeAction/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME, getDiagnosticsAndTimeout } from '../../helper';
+import { activateLS, showFile, getDiagnosticsAndTimeout } from '../../helper';
 import { getDocUri, sameLineRange } from '../../util';
 
 describe('Should do codeAction', () => {
@@ -9,7 +9,6 @@ describe('Should do codeAction', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('finds codeAction for unused import', async () => {

--- a/test/lsp/features/codeAction/basic.test.ts
+++ b/test/lsp/features/codeAction/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME, getDiagnosticsAndTimeout } from '../../helper';
 import { getDocUri, sameLineRange } from '../../util';
 
 describe('Should do codeAction', () => {
@@ -9,10 +9,6 @@ describe('Should do codeAction', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
-
-    // More sleep for waiting diagnostics
-    await sleep(FILE_LOAD_SLEEP_TIME);
     await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
@@ -34,8 +30,7 @@ interface CodeAction {
 }
 
 async function testCodeAction(docUri: vscode.Uri, range: vscode.Range, expectedActions: CodeAction[]) {
-  // For diagnostics to show up
-  await sleep(2000);
+  await getDiagnosticsAndTimeout(docUri);
 
   const result = (await vscode.commands.executeCommand(
     'vscode.executeCodeActionProvider',

--- a/test/lsp/features/completion/pathCompletion.test.ts
+++ b/test/lsp/features/completion/pathCompletion.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, getDocUri } from '../../util';
 import { testCompletion } from './helper';
 import { CompletionItemKind } from 'vscode';
@@ -9,9 +9,6 @@ describe('Should do path completion for import', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(scriptDocUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
-    // TS LS completion starts slow.
-    await sleep(2000);
   });
 
   it('completes local file names when importing', async () => {

--- a/test/lsp/features/completion/scaffold.test.ts
+++ b/test/lsp/features/completion/scaffold.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, getDocUri } from '../../util';
 import { testCompletion } from './helper';
 
@@ -8,9 +8,6 @@ describe('Should autocomplete scaffold snippets', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(scriptDocUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
-    // TS LS completion starts slow.
-    await sleep(2000);
   });
 
   it('completes all scaffold snippets', async () => {

--- a/test/lsp/features/completion/script.test.ts
+++ b/test/lsp/features/completion/script.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, getDocUri } from '../../util';
 import { testCompletion } from './helper';
 
@@ -8,9 +8,6 @@ describe('Should autocomplete for <script>', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(scriptDocUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
-    // TS LS completion starts slow.
-    await sleep(2000);
   });
 
   it('completes module names when importing', async () => {

--- a/test/lsp/features/completion/style.test.ts
+++ b/test/lsp/features/completion/style.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { testCompletion } from './helper';
 import { position, getDocUri } from '../../util';
 
@@ -10,7 +10,6 @@ describe('Should autocomplete for <style>', () => {
     await activateLS();
     await showFile(docUri);
     await showFile(doubleDocUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   describe('Should complete <style> section for all languages', () => {

--- a/test/lsp/features/definition/basic.test.ts
+++ b/test/lsp/features/definition/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { location, position, sameLineLocation, getDocUri } from '../../util';
 
 describe('Should find definition', () => {
@@ -9,7 +9,6 @@ describe('Should find definition', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('finds definition for this.msg', async () => {

--- a/test/lsp/features/diagnostics/basic.test.ts
+++ b/test/lsp/features/diagnostics/basic.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { sameLineRange, range, getDocUri } from '../../util';
 import { testDiagnostics } from './helper';
 import { DiagnosticTag } from 'vscode-languageclient';
@@ -10,7 +10,6 @@ describe('Should find common diagnostics for all regions', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows diagnostic errors for <script> region', async () => {

--- a/test/lsp/features/diagnostics/eslint.test.ts
+++ b/test/lsp/features/diagnostics/eslint.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { sameLineRange, getDocUri } from '../../util';
 import { testDiagnostics } from './helper';
 
@@ -9,7 +9,6 @@ describe('Should find diagnostics using eslint-plugin-vue', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows diagnostic errors for template errors', async () => {

--- a/test/lsp/features/diagnostics/eslint.test.ts
+++ b/test/lsp/features/diagnostics/eslint.test.ts
@@ -15,19 +15,19 @@ describe('Should find diagnostics using eslint-plugin-vue', () => {
     const expectedDiagnostics: vscode.Diagnostic[] = [
       {
         severity: vscode.DiagnosticSeverity.Error,
-        message: "\n[vue/require-v-for-key]\nElements in iteration expect to have 'v-bind:key' directives.",
+        message: "[vue/require-v-for-key]\nElements in iteration expect to have 'v-bind:key' directives.",
         range: sameLineRange(2, 4, 23),
         source: 'eslint-plugin-vue'
       },
       {
         severity: vscode.DiagnosticSeverity.Error,
-        message: "\n[vue/no-unused-vars]\n'i' is defined but never used.",
+        message: "[vue/no-unused-vars]\n'i' is defined but never used.",
         range: sameLineRange(2, 15, 16),
         source: 'eslint-plugin-vue'
       },
       {
         severity: vscode.DiagnosticSeverity.Error,
-        message: '\n[vue/no-multiple-template-root]\nThe template root requires exactly one element.',
+        message: '[vue/no-multiple-template-root]\nThe template root requires exactly one element.',
         range: sameLineRange(6, 2, 13),
         source: 'eslint-plugin-vue'
       }

--- a/test/lsp/features/diagnostics/helper.ts
+++ b/test/lsp/features/diagnostics/helper.ts
@@ -1,13 +1,10 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { sleep } from '../../helper';
+import { getDiagnosticsAndTimeout } from '../../helper';
 import * as _ from 'lodash';
 
 export async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: vscode.Diagnostic[]) {
-  // For diagnostics to show up
-  await sleep(2000);
-
-  const result = vscode.languages.getDiagnostics(docUri);
+  const result = await getDiagnosticsAndTimeout(docUri);
 
   expectedDiagnostics.forEach((ed) => {
     assert.ok(

--- a/test/lsp/features/diagnostics/unused.test.ts
+++ b/test/lsp/features/diagnostics/unused.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { sameLineRange, getDocUri } from '../../util';
 import { testDiagnostics } from './helper';
 import { DiagnosticTag } from 'vscode-languageclient';
@@ -10,7 +10,6 @@ describe('Should find diagnostics for unused variables', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows diagnostic errors for unused variables', async () => {

--- a/test/lsp/features/documentColor/basic.test.ts
+++ b/test/lsp/features/documentColor/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, sameLineRange, getDocUri } from '../../util';
 
 describe('Should do documentColor', () => {
@@ -9,7 +9,6 @@ describe('Should do documentColor', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME * 2);
   });
 
   it('show no duplicate document colors', async () => {

--- a/test/lsp/features/documentHighlight/basic.test.ts
+++ b/test/lsp/features/documentHighlight/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, sameLineRange, getDocUri } from '../../util';
 
 describe('Should do documentHighlight', () => {
@@ -9,7 +9,6 @@ describe('Should do documentHighlight', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows highlights for <div> tags', async () => {

--- a/test/lsp/features/documentLink/basic.test.ts
+++ b/test/lsp/features/documentLink/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { sameLineRange, getDocUri } from '../../util';
 
 describe('Should do documentLink', () => {
@@ -9,7 +9,6 @@ describe('Should do documentLink', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME * 3);
   });
 
   it('shows all documentLinks for Basic.vue', async () => {

--- a/test/lsp/features/documentSymbol/basic.test.ts
+++ b/test/lsp/features/documentSymbol/basic.test.ts
@@ -66,7 +66,6 @@ describe('Should do documentSymbol', () => {
 
 async function testSymbol(docUri: vscode.Uri, expectedSymbols: PartialDocumentSymbol[]) {
   await showFile(docUri);
-  await sleep(2000);
 
   const result = (await vscode.commands.executeCommand(
     'vscode.executeDocumentSymbolProvider',

--- a/test/lsp/features/documentSymbol/basic.test.ts
+++ b/test/lsp/features/documentSymbol/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { range, getDocUri } from '../../util';
 
 describe('Should do documentSymbol', () => {
@@ -9,7 +9,6 @@ describe('Should do documentSymbol', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows all documentSymbols for Basic.vue', async () => {

--- a/test/lsp/features/formatting/basic.test.ts
+++ b/test/lsp/features/formatting/basic.test.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as assert from 'assert';
-import { activateLS, showFile, sleep, readFileAsync, setEditorContent, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile, readFileAsync, setEditorContent } from '../../helper';
 import { getDocUri, getDocPath } from '../../util';
 
 describe('Should format', () => {
@@ -17,8 +17,6 @@ describe('Should format', () => {
     for (let i = 0; i < cases.length; i++) {
       await showFile(getDocUri(`formatting/${cases[i]}.vue`));
     }
-
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   for (let i = 0; i < cases.length; i++) {

--- a/test/lsp/features/hover/basic.test.ts
+++ b/test/lsp/features/hover/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, sameLineRange, getDocUri } from '../../util';
 
 describe('Should do hover', () => {
@@ -9,7 +9,6 @@ describe('Should do hover', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('shows hover for <img> tag', async () => {

--- a/test/lsp/features/references/basic.test.ts
+++ b/test/lsp/features/references/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, sleep, showFile, FILE_LOAD_SLEEP_TIME } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { position, location, sameLineLocation, getDocUri } from '../../util';
 
 describe('Should find references', () => {
@@ -9,9 +9,6 @@ describe('Should find references', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(docUri);
-    await sleep(FILE_LOAD_SLEEP_TIME);
-    // Wait a bit more for references to load
-    await sleep(FILE_LOAD_SLEEP_TIME);
   });
 
   it('finds references for this.msg', async () => {

--- a/test/lsp/helper.ts
+++ b/test/lsp/helper.ts
@@ -45,3 +45,17 @@ export function readFileAsync(path: string) {
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// Retry to get diagnostics until length > 0 or timeout
+export async function getDiagnosticsAndTimeout(docUri: vscode.Uri, timeout = 5000) {
+  const startTime = Date.now();
+
+  let result = vscode.languages.getDiagnostics(docUri);
+
+  while (result.length <= 0 && startTime + timeout > Date.now()) {
+    result = vscode.languages.getDiagnostics(docUri);
+    await sleep(100);
+  }
+
+  return result;
+}

--- a/test/vue3/features/completion/basic.test.ts
+++ b/test/vue3/features/completion/basic.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, showFile, sleep, FILE_LOAD_SLEEP_TIME } from '../../../lsp/helper';
+import { activateLS, showFile } from '../../../lsp/helper';
 import { position, getDocUri } from '../../util';
 import { testCompletion } from './helper';
 import { CompletionItemKind } from 'vscode';
@@ -9,7 +9,6 @@ describe('Vue 3 integration test', () => {
   before('activate', async () => {
     await activateLS();
     await showFile(fileUri);
-    await sleep(FILE_LOAD_SLEEP_TIME * 2);
   });
 
   describe('Should complete Vue 3 options', () => {


### PR DESCRIPTION
- [x] retry to get diagnostics until length > 0 or timeout
- [x] remove all `sleep` function and can await extension `activate`
