### PR TITLE
Fix no props completion when child component `export default {}` ends with `;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Load different `eslint-plugin-vue` rulesets depending on workspace vue version. #2015.
 - Remove leading empty line in diagnostic errors. #2067.
 - `"vetur.completion.tagCasing": "initial"` causes double tag completion. #2053
+- 🙌 Fix no props completion when child component `export default {}` ends with `;`. Thanks to contribution from [@yoyo930021](@yoyo930021). #1775 and #1791.
 - 🙌 Fix object property completion when have hyphen. Thanks to contribution from [@yoyo930021](@yoyo930021). #1804 and #1808.
 - 🙌 SFC without a script tag show an error when trying to import. Thanks to contribution from [@yoyo930021](@yoyo930021). #1187 and #1806.
 - 🙌 Fix initializationOptions: Cannot read property 'config' of undefined. Thanks to contribution from [Dawid Pakuła](https://github.com/zulus). #1897 and #1341.

--- a/server/src/modes/script/childComponents.ts
+++ b/server/src/modes/script/childComponents.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { getLastChild, buildDocumentation, getObjectLiteralExprFromExportExpr } from './componentInfo';
+import { getLastChild, buildDocumentation, getDefaultExportObjectLiteralExpr } from './componentInfo';
 import { T_TypeScript } from '../../services/dependencyService';
 
 interface InternalChildComponent {
@@ -58,7 +58,10 @@ export function getChildComponents(
       if (objectLiteralSymbol.flags & tsModule.SymbolFlags.Alias) {
         const definitionObjectLiteralSymbol = checker.getAliasedSymbol(objectLiteralSymbol);
         if (definitionObjectLiteralSymbol.valueDeclaration) {
-          const defaultExportExpr = getLastChild(definitionObjectLiteralSymbol.valueDeclaration);
+          const defaultExportExpr = getDefaultExportObjectLiteralExpr(
+            tsModule,
+            definitionObjectLiteralSymbol.valueDeclaration.getSourceFile()
+          );
           if (!defaultExportExpr) {
             return;
           }
@@ -71,7 +74,7 @@ export function getChildComponents(
               start: defaultExportExpr.getStart(undefined, true),
               end: defaultExportExpr.getEnd()
             },
-            defaultExportExpr: getObjectLiteralExprFromExportExpr(tsModule, defaultExportExpr)
+            defaultExportExpr
           });
         }
       }

--- a/server/src/modes/script/componentInfo.ts
+++ b/server/src/modes/script/componentInfo.ts
@@ -81,7 +81,7 @@ export function analyzeDefaultExportExpr(
   };
 }
 
-function getDefaultExportObjectLiteralExpr(
+export function getDefaultExportObjectLiteralExpr(
   tsModule: T_TypeScript,
   sourceFile: ts.SourceFile
 ): ts.Expression | undefined {

--- a/test/interpolation/fixture/completion/Basic.vue
+++ b/test/interpolation/fixture/completion/Basic.vue
@@ -53,5 +53,5 @@ export default {
       console.log(this.msg)
     }
   }
-}
+};
 </script>

--- a/test/lsp/features/completion/template.test.ts
+++ b/test/lsp/features/completion/template.test.ts
@@ -3,15 +3,9 @@ import { getDocUri, position } from '../../util';
 import { testCompletion } from './helper';
 
 describe('Should autocomplete for <template>', () => {
-  const basicUri = getDocUri('completion/template/Basic.vue');
-  const elementUri = getDocUri('completion/template/Element.vue');
-  const quasarUri = getDocUri('completion/template/Quasar.vue');
-  const vuetifyUri = getDocUri('completion/template/Vuetify.vue');
-  const workspaceCustomTagsUri = getDocUri('completion/template/WorkspaceCustomTags.vue');
-
-  const parentUri = getDocUri('completion/template/childComponent/Parent.vue');
-
   describe('Should complete <template> section', () => {
+    const basicUri = getDocUri('completion/template/Basic.vue');
+
     it('completes directives such as v-if', async () => {
       await testCompletion(basicUri, position(1, 8), ['v-if', 'v-cloak']);
     });
@@ -66,6 +60,8 @@ describe('Should autocomplete for <template>', () => {
   });
 
   describe('Should complete element-ui components', () => {
+    const elementUri = getDocUri('completion/template/Element.vue');
+
     it('completes <el-button> and <el-card>', async () => {
       await testCompletion(elementUri, position(2, 5), ['el-button', 'el-card']);
     });
@@ -76,6 +72,8 @@ describe('Should autocomplete for <template>', () => {
   });
 
   describe('Should complete Quasar components', () => {
+    const quasarUri = getDocUri('completion/template/Quasar.vue');
+
     it('completes <q-btn>', async () => {
       await testCompletion(quasarUri, position(2, 5), ['q-btn']);
     });
@@ -86,6 +84,8 @@ describe('Should autocomplete for <template>', () => {
   });
 
   describe('Should complete Vuetify components', () => {
+    const vuetifyUri = getDocUri('completion/template/Vuetify.vue');
+
     it('completes <v-btn>', async () => {
       await testCompletion(vuetifyUri, position(2, 5), ['v-btn']);
     });
@@ -96,6 +96,8 @@ describe('Should autocomplete for <template>', () => {
   });
 
   describe('Should complete tags defined in workspace', () => {
+    const workspaceCustomTagsUri = getDocUri('completion/template/WorkspaceCustomTags.vue');
+
     it('completes <foo-tag>', async () => {
       await testCompletion(workspaceCustomTagsUri, position(2, 6), ['foo-tag']);
     });
@@ -106,6 +108,8 @@ describe('Should autocomplete for <template>', () => {
   });
 
   describe('Parent - Child component completion', () => {
+    const parentUri = getDocUri('completion/template/childComponent/Parent.vue');
+
     it('completes tags/attributes for ChildComp', async () => {
       const c = workspace.getConfiguration();
 
@@ -119,6 +123,11 @@ describe('Should autocomplete for <template>', () => {
 
       // set it back
       await c.update('vetur.completion.tagCasing', undefined, ConfigurationTarget.Global);
+    });
+
+    const parent1775Uri = getDocUri('completion/template/childComponent/Parent1775.vue');
+    it('AAA completes child when child `export default {}` ends with `;`', async () => {
+      await testCompletion(parent1775Uri, position(1, 13), ['attr']);
     });
   });
 });

--- a/test/lsp/fixture/completion/template/childComponent/Child.vue
+++ b/test/lsp/fixture/completion/template/childComponent/Child.vue
@@ -16,5 +16,5 @@ export default {
       type: Number
     }
   }
-}
+};
 </script>

--- a/test/lsp/fixture/completion/template/childComponent/Child1775.vue
+++ b/test/lsp/fixture/completion/template/childComponent/Child1775.vue
@@ -1,0 +1,10 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+// https://github.com/vuejs/vetur/issues/1775
+export default {
+  props: ['attr']
+};
+</script>

--- a/test/lsp/fixture/completion/template/childComponent/Parent1775.vue
+++ b/test/lsp/fixture/completion/template/childComponent/Parent1775.vue
@@ -1,0 +1,13 @@
+<template>
+  <child1775 ></child1775>
+</template>
+
+<script>
+import Child1775 from './Child1775.vue'
+
+export default {
+  components: {
+    Child1775
+  }
+}
+</script>


### PR DESCRIPTION
Fixed #1775 