### PR TITLE
Pass correct PID to language server

### DIFF
--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -64,6 +64,7 @@ async function prepareClientConnection(workspaceUri: Uri) {
   const init: InitializeParams = {
     rootPath: workspaceUri.fsPath,
     rootUri: workspaceUri.toString(),
+    processId: process.pid,
     ...params
   } as InitializeParams;
 

--- a/vti/src/initParams.ts
+++ b/vti/src/initParams.ts
@@ -1,8 +1,4 @@
 export const params = {
-  /**
-   * Doesn't matter as long as its positive
-   */
-  processId: 1,
   capabilities: {},
   initializationOptions: {
     config: {


### PR DESCRIPTION
[VS Code Language Server sends `SIG_0` to parent process](https://github.com/microsoft/vscode-languageserver-node/blob/master/server/src/main.ts#L1899-L1911), to make sure it's still alive. However, calling `kill` with `SIG_0` also performs permission check, and since VTI passes 1 as processId - `kill` fails and language server thinks the parent process doesn't exist.
This PR suggests a fix to this problem by passing a real PID.

Resolves: #1699