### PR TITLE
feat: treat nuxt-buefy as Buefy framework

### DIFF
--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -73,7 +73,7 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     if (dependencies['bootstrap-vue']) {
       settings['bootstrap'] = true;
     }
-    if (dependencies['buefy']) {
+    if (dependencies['buefy'] || dependencies['nuxt-buefy']) {
       settings['buefy'] = true;
     }
     if (dependencies['vuetify'] || devDependencies['vuetify']) {


### PR DESCRIPTION
[nuxt-buefy](https://github.com/buefy/nuxt-buefy) is the nuxt plugin developed by [Buefy](https://github.com/buefy) official team.
And, this plugin contains latest buefy package.

So we can think of it as one of the buefy frameworks, just like the relationship between `vuetify` and `@nuxtjs/vuetify`.