### PR TITLE
fix: VTI - Wrong first arg

### DIFF
--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -124,17 +124,9 @@ async function getDiagnostics(workspaceUri: Uri) {
 
 (async () => {
   const myArgs = process.argv.slice(2);
-  // no args
-  if (myArgs.length === 0) {
-    console.log('Vetur Terminal Interface');
-    console.log('');
-    console.log('Usage:');
-    console.log('');
-    console.log('  vti diagnostics ---- Print all diagnostics');
-    console.log('');
-  }
+
   // vls diagnostics
-  else if (myArgs[0] === 'diagnostics') {
+  if (myArgs.length > 0 && myArgs[0] === 'diagnostics') {
     console.log('Getting Vetur diagnostics');
     let workspaceUri;
 
@@ -158,6 +150,14 @@ async function getDiagnostics(workspaceUri: Uri) {
       console.log(chalk.red(`VTI found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`));
       process.exit(1);
     }
+  } else {
+    // no args or wrong first args
+    console.log('Vetur Terminal Interface');
+    console.log('');
+    console.log('Usage:');
+    console.log('');
+    console.log('  vti diagnostics ---- Print all diagnostics');
+    console.log('');
   }
 })().catch(_err => {
   console.error('VTI operation failed');


### PR DESCRIPTION
I fix a situation when you write incorrect first args.
Original version no display message.
I change the condition to display message always when not run any other action.
