### PR TITLE
feat: detect tags from @nuxt/components

### DIFF
--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -96,13 +96,7 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
       // and enable Quasar later below in the for()
       dependencies['quasar-framework'] = '^0.0.17';
     }
-    if (
-      dependencies['nuxt'] ||
-      dependencies['nuxt-legacy'] ||
-      dependencies['nuxt-edge'] ||
-      dependencies['nuxt-ts'] ||
-      dependencies['nuxt-ts-edge']
-    ) {
+    if (dependencies['nuxt'] || dependencies['nuxt-edge'] || devDependencies['nuxt'] || devDependencies['nuxt-edge']) {
       const nuxtTagProvider = getNuxtTagProvider(workspacePath);
       if (nuxtTagProvider) {
         settings['nuxt'] = true;

--- a/server/src/modes/template/tagProviders/nuxtTags.ts
+++ b/server/src/modes/template/tagProviders/nuxtTags.ts
@@ -9,7 +9,9 @@ export function getNuxtTagProvider(workspacePath: string) {
     if (tryResolve(join(source, 'package.json'), workspacePath)) {
       nuxtTags = tryRequire(join(source, 'vetur/nuxt-tags.json'), workspacePath);
       nuxtAttributes = tryRequire(join(source, 'vetur/nuxt-attributes.json'), workspacePath);
-      break;
+      if (nuxtTags) {
+        break;
+      }
     }
   }
 
@@ -18,14 +20,8 @@ export function getNuxtTagProvider(workspacePath: string) {
 
   return getExternalTagProvider(
     'nuxt',
-    {
-      ...nuxtTags,
-      ...componentsTags
-    },
-    {
-      ...nuxtAttributes,
-      ...componentsAttributes
-    }
+    { ...nuxtTags, ...componentsTags },
+    { ...nuxtAttributes, ...componentsAttributes }
   );
 }
 
@@ -33,9 +29,7 @@ function tryRequire(modulePath: string, workspacePath: string) {
   try {
     const resolved = tryResolve(modulePath, workspacePath);
     return resolved ? require(resolved) : undefined;
-  } catch (_err) {
-    return {};
-  }
+  } catch (_err) {}
 }
 
 function tryResolve(modulePath: string, workspacePath: string) {

--- a/server/src/modes/template/tagProviders/nuxtTags.ts
+++ b/server/src/modes/template/tagProviders/nuxtTags.ts
@@ -1,43 +1,47 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { join } from 'path';
 import { getExternalTagProvider } from './externalTagProviders';
 
-const NUXT_VUE_APP_PATH = 'node_modules/@nuxt/vue-app';
-const NUXT_EDGE_VUE_APP_PATH = 'node_modules/@nuxt/vue-app-edge';
+const NUXT_JSON_SOURCES = ['@nuxt/vue-app-edge', '@nuxt/vue-app', 'nuxt-helper-json'];
 
 export function getNuxtTagProvider(workspacePath: string) {
-  if (fs.existsSync(path.resolve(workspacePath, NUXT_VUE_APP_PATH, 'package.json'))) {
-    const { nuxtTags, nuxtAttributes } = getNuxtTagsAndAttributes(NUXT_VUE_APP_PATH);
-    return getExternalTagProvider('nuxt', nuxtTags, nuxtAttributes);
+  let nuxtTags, nuxtAttributes;
+  for (const source of NUXT_JSON_SOURCES) {
+    if (tryResolve(join(source, 'package.json'), workspacePath)) {
+      nuxtTags = tryRequire(join(source, 'vetur/nuxt-tags.json'), workspacePath);
+      nuxtAttributes = tryRequire(join(source, 'vetur/nuxt-attributes.json'), workspacePath);
+      break;
+    }
   }
 
-  if (fs.existsSync(path.resolve(workspacePath, NUXT_EDGE_VUE_APP_PATH, 'package.json'))) {
-    const { nuxtTags, nuxtAttributes } = getNuxtTagsAndAttributes(NUXT_EDGE_VUE_APP_PATH);
-    return getExternalTagProvider('nuxt', nuxtTags, nuxtAttributes);
+  const componentsTags = tryRequire(join(workspacePath, '.nuxt/vetur/tags.json'), workspacePath);
+  const componentsAttributes = tryRequire(join(workspacePath, '.nuxt/vetur/attributes.json'), workspacePath);
+
+  return getExternalTagProvider(
+    'nuxt',
+    {
+      ...nuxtTags,
+      ...componentsTags
+    },
+    {
+      ...nuxtAttributes,
+      ...componentsAttributes
+    }
+  );
+}
+
+function tryRequire(modulePath: string, workspacePath: string) {
+  try {
+    const resolved = tryResolve(modulePath, workspacePath);
+    return resolved ? require(resolved) : undefined;
+  } catch (_err) {
+    return {};
   }
 }
 
-function getNuxtTagsAndAttributes(nuxtVueAppPath: string) {
-  let nuxtVer = '0.0.0';
+function tryResolve(modulePath: string, workspacePath: string) {
   try {
-    nuxtVer = require(path.resolve(nuxtVueAppPath, 'package.json')).version;
-  } catch (err) {}
-
-  if (nuxtVer < '2.4.0') {
-    const nuxtTags = require('nuxt-helper-json/nuxt-tags.json');
-    const nuxtAttributes = require('nuxt-helper-json/nuxt-attributes.json');
-
-    return {
-      nuxtTags,
-      nuxtAttributes
-    };
-  } else {
-    const nuxtTags = require(path.resolve(nuxtVueAppPath, 'vetur/nuxt-tags.json'));
-    const nuxtAttributes = require(path.resolve(nuxtVueAppPath, 'vetur/nuxt-attributes.json'));
-
-    return {
-      nuxtTags,
-      nuxtAttributes
-    };
-  }
+    return require.resolve(modulePath, {
+      paths: [workspacePath, __dirname]
+    });
+  } catch (_err) {}
 }


### PR DESCRIPTION
Hi :) 

This PR adds integration with [nuxt/components](https://github.com/nuxt/components) (nuxt/components#14). I also did some refactors for `nuxtTags.ts` and also checking `devDependencies`. `nuxt-legacy` is no longer valid and `nuxt-ts` is installed alongside with nuxt dependency.

![image](https://user-images.githubusercontent.com/5158436/82257624-a903ed00-9958-11ea-9db6-efadf4affd3a.png)

Locally working. The only issue is that I don't know if we can somehow reload vetur tags or not?