### PR TITLE
Add support for multi-root workspace

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -9,10 +9,22 @@ import {
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 
-export function initializeLanguageClient(vlsModulePath: string, globalSnippetDir: string): LanguageClient {
+export function initializeLanguageClient(
+  vlsModulePath: string,
+  globalSnippetDir: string,
+  workspaceFolder?: vscode.WorkspaceFolder
+): LanguageClient {
   const debugOptions = { execArgv: ['--nolazy', '--inspect=6005'] };
 
-  const documentSelector = ['vue'];
+  const documentSelector = workspaceFolder
+    ? [
+        {
+          language: 'vue',
+          scheme: 'file',
+          pattern: `${workspaceFolder.uri.fsPath}/**/*`
+        }
+      ]
+    : ['vue'];
   const config = vscode.workspace.getConfiguration();
 
   let serverPath;
@@ -56,7 +68,8 @@ export function initializeLanguageClient(vlsModulePath: string, globalSnippetDir
       config,
       globalSnippetDir
     },
-    revealOutputChannelOn: RevealOutputChannelOn.Never
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
+    workspaceFolder
   };
 
   return new LanguageClient('vetur', 'Vue Language Server', serverOptions, clientOptions);

--- a/client/vueMain.ts
+++ b/client/vueMain.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { LanguageClient, WorkspaceEdit } from 'vscode-languageclient';
+import { LanguageClient, WorkspaceEdit, WorkspaceFolder } from 'vscode-languageclient';
 import { generateGrammarCommandHandler } from './commands/generateGrammarCommand';
 import { registerLanguageConfigurations } from './languages';
 import { initializeLanguageClient } from './client';
@@ -11,6 +11,11 @@ import {
 } from './commands/virtualFileCommand';
 import { getGlobalSnippetDir } from './userSnippetDir';
 import { generateOpenUserScaffoldSnippetFolderCommand } from './commands/openUserScaffoldSnippetFolderCommand';
+
+/**
+ * Map of workspace folder URI -> LanguageClient
+ */
+const clients = new Map<string, LanguageClient>();
 
 export async function activate(context: vscode.ExtensionContext) {
   const isInsiders = vscode.env.appName.includes('Insiders');
@@ -28,6 +33,15 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('vetur.generateGrammar', generateGrammarCommandHandler(context.extensionPath))
   );
 
+  registerLanguageConfigurations();
+
+  /**
+   * Vue Language Server path
+   * To be able to work with multiple workspaces, we initialize one language service per workspace folder
+   */
+
+  const serverModule = context.asAbsolutePath(join('server', 'dist', 'vueServerMain.js'));
+
   /**
    * Open custom snippet folder
    */
@@ -38,40 +52,74 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('vetur.applyWorkspaceEdits', (args: WorkspaceEdit) => {
-      const edit = client.protocol2CodeConverter.asWorkspaceEdit(args)!;
-      vscode.workspace.applyEdit(edit);
-    })
-  );
+  function onDidOpenTextDocument(document: vscode.TextDocument) {
+    const client = initializeClientForTextDocument(context, serverModule, globalSnippetDir, document);
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('vetur.chooseTypeScriptRefactoring', (args: any) => {
-      client
-        .sendRequest<vscode.Command | undefined>('requestCodeActionEdits', args)
-        .then(command => command && vscode.commands.executeCommand(command.command, ...command.arguments!));
-    })
-  );
+    // TODO handle commands properly
+    if (!client || clients.size > 1) {
+      return;
+    }
 
-  registerLanguageConfigurations();
+    context.subscriptions.push(
+      vscode.commands.registerCommand('vetur.applyWorkspaceEdits', (args: WorkspaceEdit) => {
+        const edit = client.protocol2CodeConverter.asWorkspaceEdit(args)!;
+        vscode.workspace.applyEdit(edit);
+      })
+    );
 
-  /**
-   * Vue Language Server Initialization
-   */
+    context.subscriptions.push(
+      vscode.commands.registerCommand('vetur.chooseTypeScriptRefactoring', (args: any) => {
+        client
+          .sendRequest<vscode.Command | undefined>('requestCodeActionEdits', args)
+          .then(command => command && vscode.commands.executeCommand(command.command, ...command.arguments!));
+      })
+    );
+  }
 
-  const serverModule = context.asAbsolutePath(join('server', 'dist', 'vueServerMain.js'));
-  const client = initializeLanguageClient(serverModule, globalSnippetDir);
-  context.subscriptions.push(client.start());
+  vscode.workspace.onDidOpenTextDocument(onDidOpenTextDocument);
+  vscode.workspace.textDocuments.forEach(onDidOpenTextDocument);
 
-  client
-    .onReady()
-    .then(() => {
-      registerCustomClientNotificationHandlers(client);
-      registerCustomLSPCommands(context, client);
-    })
-    .catch(e => {
-      console.log('Client initialization failed');
-    });
+  vscode.workspace.onDidChangeWorkspaceFolders(event => {
+    for (const folder of event.removed) {
+      const client = clients.get(folder.uri.toString());
+      if (client) {
+        clients.delete(folder.uri.toString());
+        client.stop();
+      }
+    }
+  });
+}
+
+function initializeClientForTextDocument(
+  context: vscode.ExtensionContext,
+  serverModule: string,
+  globalSnippetDir: string,
+  document: vscode.TextDocument
+): LanguageClient | undefined {
+  const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+
+  if (!folder || document.languageId !== 'vue') {
+    return;
+  }
+
+  if (!clients.has(folder.uri.toString())) {
+    const client = initializeLanguageClient(serverModule, globalSnippetDir, folder);
+
+    client
+      .onReady()
+      .then(() => {
+        registerCustomClientNotificationHandlers(client);
+        registerCustomLSPCommands(context, client);
+      })
+      .catch(e => {
+        console.log(`Client initialization failed for workspace: ${folder.uri.toString()}`);
+      });
+
+    context.subscriptions.push(client.start());
+    clients.set(folder.uri.toString(), client);
+
+    return client;
+  }
 }
 
 function registerCustomClientNotificationHandlers(client: LanguageClient) {

--- a/server/src/vueServerMain.ts
+++ b/server/src/vueServerMain.ts
@@ -11,7 +11,7 @@ connection.onInitialize(
   async (params: InitializeParams): Promise<InitializeResult> => {
     await vls.init(params);
 
-    console.log('Vetur initialized');
+    console.log(`Vetur initialized for workspace folder: ${params.rootPath}`);
 
     return {
       capabilities: vls.capabilities


### PR DESCRIPTION
Should fix #424 and #815 

Following the example at https://github.com/Microsoft/vscode-extension-samples/tree/master/lsp-multi-server-sample 

It creates a new VLS for each of the workspace folders. 

I'll need help to add proper test coverage and check if every command is working properly (every test passes, but it's probably not tested against multi-root workspace). 
