### PR TITLE
Fix for Issue #1794 - Use babel instead babylon parser

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -481,7 +481,7 @@ export async function getJavascriptMode(
         return [];
       }
 
-      const parser = scriptDoc.languageId === 'javascript' ? 'babylon' : 'typescript';
+      const parser = scriptDoc.languageId === 'javascript' ? 'babel' : 'typescript';
       const needInitialIndent = config.vetur.format.scriptInitialIndent;
       const vlsFormatConfig: VLSFormatConfig = config.vetur.format;
 


### PR DESCRIPTION
Make it compatible with Prettier 2.0. The parser option "babylon" has been replaced by "babel".