### PR TITLE
Allow analyzing Vue files in `node_modules`

### DIFF
--- a/server/src/services/typescriptService/serviceHost.ts
+++ b/server/src/services/typescriptService/serviceHost.ts
@@ -77,7 +77,6 @@ export function getServiceHost(
   updatedScriptRegionDocuments: LanguageModelCache<TextDocument>
 ): IServiceHost {
   patchTS(tsModule);
-  const vueSys = getVueSys(tsModule);
 
   let currentScriptDoc: TextDocument;
 
@@ -96,6 +95,8 @@ export function getServiceHost(
     `Initializing ServiceHost with ${initialProjectFiles.length} files: ${JSON.stringify(initialProjectFiles)}`
   );
   const scriptFileNameSet = new Set(initialProjectFiles);
+
+  const vueSys = getVueSys(tsModule, scriptFileNameSet);
 
   const vueVersion = inferVueVersion(tsModule, workspacePath);
   const compilerOptions = {
@@ -482,6 +483,6 @@ function getParsedConfig(tsModule: T_TypeScript, workspacePath: string) {
     /*existingOptions*/ {},
     configFilename,
     /*resolutionStack*/ undefined,
-    [{ extension: 'vue', isMixedContent: true }]
+    [{ extension: 'vue', isMixedContent: true, scriptKind: ts.ScriptKind.Deferred }]
   );
 }

--- a/server/src/services/typescriptService/util.ts
+++ b/server/src/services/typescriptService/util.ts
@@ -9,8 +9,8 @@ export function isVueFile(path: string) {
  * If the path ends with `.vue.ts`, it's a `.vue` file pre-processed by Vetur
  * to be used in TS Language Service
  */
-export function isVirtualVueFile(path: string) {
-  return path.endsWith('.vue.ts') && !path.includes('node_modules');
+export function isVirtualVueFile(path: string, projectFiles: Set<string>) {
+  return path.endsWith('.vue.ts') && projectFiles.has(path.slice(0, -'.ts'.length));
 }
 
 /**


### PR DESCRIPTION
- Include ".vue" files in projectFiles (using ScriptKind.Deferred)
- Use project files to determine virtual file interpolation (instead of checking for `node_modules` in path)

Fixes #1127