### PR TITLE
Prevent failure due to slow LS start

### DIFF
--- a/test/interpolation/features/beforeAll/beforeAll.test.ts
+++ b/test/interpolation/features/beforeAll/beforeAll.test.ts
@@ -1,0 +1,8 @@
+import { getDocUri } from '../../util';
+import { showFile, sleep } from '../../helper';
+
+before(async () => {
+  const docUri = getDocUri('beforeAll.vue');
+  await showFile(docUri);
+  await sleep(3000);
+});

--- a/test/interpolation/features/completion/basic.test.ts
+++ b/test/interpolation/features/completion/basic.test.ts
@@ -1,7 +1,7 @@
-import { activateLS, showFile } from '../../lsp/helper';
-import { position, getDocUri } from '../util';
-import { testCompletion, testNoSuchCompletion } from './helper';
 import { CompletionItem, CompletionItemKind, MarkdownString } from 'vscode';
+import { activateLS, showFile } from '../../helper';
+import { getDocUri, position } from '../../util';
+import { testCompletion, testNoSuchCompletion } from './helper';
 
 describe('Should autocomplete interpolation for <template>', () => {
   const templateDocUri = getDocUri('completion/Basic.vue');

--- a/test/interpolation/features/completion/helper.ts
+++ b/test/interpolation/features/completion/helper.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { showFile } from '../helper';
 import { CompletionItem, MarkdownString } from 'vscode';
+import { showFile } from '../../helper';
 
 export interface ExpectedCompletionItem extends CompletionItem {
   documentationStart?: string;

--- a/test/interpolation/features/diagnostics/basic.test.ts
+++ b/test/interpolation/features/diagnostics/basic.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { activateLS, showFile } from '../helper';
-import { getDocUri, sameLineRange } from '../util';
+import { activateLS, showFile } from '../../helper';
+import { getDocUri, sameLineRange } from '../../util';
 import { testDiagnostics, testNoDiagnostics } from './helper';
 
 describe('Should find template-diagnostics in <template> region', () => {

--- a/test/interpolation/features/diagnostics/helper.ts
+++ b/test/interpolation/features/diagnostics/helper.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as _ from 'lodash';
-import { sleep } from '../util';
-import { getDiagnosticsAndTimeout } from '../helper';
+import { getDiagnosticsAndTimeout, sleep } from '../../helper';
 
 export async function testDiagnostics(
   docUri: vscode.Uri,
@@ -51,7 +50,7 @@ export async function testDiagnostics(
 
 export async function testNoDiagnostics(docUri: vscode.Uri) {
   // For diagnostics to show up
-  await sleep(3500);
+  await sleep(3000);
 
   const result = vscode.languages.getDiagnostics(docUri);
 

--- a/test/interpolation/features/hover/basic.test.ts
+++ b/test/interpolation/features/hover/basic.test.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { activateLS, showFile } from '../../lsp/helper';
-import { position, sameLineRange, getDocUri } from '../util';
+import { activateLS, showFile } from '../../helper';
+import { position, sameLineRange, getDocUri } from '../../util';
 
 describe('Should do hover interpolation for <template>', () => {
   const docUri = getDocUri('hover/Basic.vue');

--- a/test/interpolation/fixture/beforeAll.vue
+++ b/test/interpolation/fixture/beforeAll.vue
@@ -1,0 +1,1 @@
+<!-- Open this file before testing to activate Vetur/VLS -->

--- a/test/interpolation/helper.ts
+++ b/test/interpolation/helper.ts
@@ -1,10 +1,8 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { sleep } from './util';
 import { performance } from 'perf_hooks';
 
 export const EXT_IDENTIFIER = 'octref.vetur';
-export const FILE_LOAD_SLEEP_TIME = 1500;
 
 export const ext = vscode.extensions.getExtension(EXT_IDENTIFIER);
 
@@ -56,4 +54,8 @@ export async function getDiagnosticsAndTimeout(docUri: vscode.Uri, timeout = 500
   }
 
   return result;
+}
+
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/test/interpolation/util.ts
+++ b/test/interpolation/util.ts
@@ -23,7 +23,3 @@ export const getDocPath = (p: string) => {
 export const getDocUri = (p: string) => {
   return vscode.Uri.file(getDocPath(p));
 };
-
-export function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/test/lsp/features/beforeAll/beforeAll.test.ts
+++ b/test/lsp/features/beforeAll/beforeAll.test.ts
@@ -1,0 +1,8 @@
+import { getDocUri } from '../../util';
+import { showFile, sleep } from '../../helper';
+
+before(async () => {
+  const docUri = getDocUri('beforeAll.vue');
+  await showFile(docUri);
+  await sleep(3000);
+});

--- a/test/lsp/fixture/beforeAll.vue
+++ b/test/lsp/fixture/beforeAll.vue
@@ -1,0 +1,1 @@
+<!-- Open this file before testing to activate Vetur/VLS -->

--- a/test/lsp/helper.ts
+++ b/test/lsp/helper.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import { performance } from 'perf_hooks';
 
 export const EXT_IDENTIFIER = 'octref.vetur';
-export const FILE_LOAD_SLEEP_TIME = 1500;
 
 export const ext = vscode.extensions.getExtension(EXT_IDENTIFIER);
 

--- a/test/vue3/features/beforeAll/beforeAll.test.ts
+++ b/test/vue3/features/beforeAll/beforeAll.test.ts
@@ -1,0 +1,8 @@
+import { getDocUri } from '../../util';
+import { showFile, sleep } from '../../helper';
+
+before(async () => {
+  const docUri = getDocUri('beforeAll.vue');
+  await showFile(docUri);
+  await sleep(3000);
+});

--- a/test/vue3/features/diagnostics/eslint.test.ts
+++ b/test/vue3/features/diagnostics/eslint.test.ts
@@ -1,4 +1,4 @@
-import { activateLS, FILE_LOAD_SLEEP_TIME, showFile, sleep } from '../../helper';
+import { activateLS, showFile } from '../../helper';
 import { getDocUri } from '../../util';
 import { testNoDiagnostics } from './helper';
 

--- a/test/vue3/features/diagnostics/helper.ts
+++ b/test/vue3/features/diagnostics/helper.ts
@@ -35,7 +35,7 @@ export async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: v
 
 export async function testNoDiagnostics(docUri: vscode.Uri) {
   // For diagnostics to show up
-  await sleep(2000);
+  await sleep(3000);
 
   const result = vscode.languages.getDiagnostics(docUri);
 

--- a/test/vue3/fixture/beforeAll.vue
+++ b/test/vue3/fixture/beforeAll.vue
@@ -1,0 +1,1 @@
+<!-- Open this file before testing to activate Vetur/VLS -->

--- a/test/vue3/helper.ts
+++ b/test/vue3/helper.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import { performance } from 'perf_hooks';
 
 export const EXT_IDENTIFIER = 'octref.vetur';
-export const FILE_LOAD_SLEEP_TIME = 1500;
 
 export const ext = vscode.extensions.getExtension(EXT_IDENTIFIER);
 

--- a/test/vue3/util.ts
+++ b/test/vue3/util.ts
@@ -23,7 +23,3 @@ export const getDocPath = (p: string) => {
 export const getDocUri = (p: string) => {
   return vscode.Uri.file(getDocPath(p));
 };
-
-export function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
Windows CI sometimes fails on first test (waiting for codeActions). I think the issue is that LS hasn't started.
This PR fixes that by opening a Vue file before each integration test suite and waiting 3s.