### PR TITLE
Fix prop validation diagnostics not working for PascalCase components in templates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Linkify all vue/vue-router tags to their API doc. #2133.
 - Component Data - `type: 'boolean'` should trigger completion without `=""`. #2127.
 - Component Data doesn't work if it comes from devDependencies. #2132.
+- 🙌 Props of `<PascalCase>` components in templates will now be validated [@triforcely](https://github.com/triforcely). #2168.
 - 🙌 Add yarn@berry support and use `typescript.tsdk` setting for loading TypeScript in VLS. Thanks to contribution from [Alexandre Bonaventure Geissmann](https://github.com/AlexandreBonaventure). #1711, #1737 and #1996.
 - 🙌 Add support for analyzing vue-class-component and vue-property-decorator. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #864, #1105 and #1323.
 - 🙌 Remove lsp client-side commands to improve integration with third party lsp client. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2137.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Linkify all vue/vue-router tags to their API doc. #2133.
 - Component Data - `type: 'boolean'` should trigger completion without `=""`. #2127.
 - Component Data doesn't work if it comes from devDependencies. #2132.
-- 🙌 Validate props of `<PascalCase>` components in templates. Thanks to contribution from [@triforcely](https://github.com/triforcely). #2168.
+- 🙌 Validate props of `<PascalCase>` components in templates. Thanks to contribution from [Michał Wilski](https://github.com/triforcely). #2168.
 - 🙌 Add yarn@berry support and use `typescript.tsdk` setting for loading TypeScript in VLS. Thanks to contribution from [Alexandre Bonaventure Geissmann](https://github.com/AlexandreBonaventure). #1711, #1737 and #1996.
 - 🙌 Add support for analyzing vue-class-component and vue-property-decorator. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #864, #1105 and #1323.
 - 🙌 Remove lsp client-side commands to improve integration with third party lsp client. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2137.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Linkify all vue/vue-router tags to their API doc. #2133.
 - Component Data - `type: 'boolean'` should trigger completion without `=""`. #2127.
 - Component Data doesn't work if it comes from devDependencies. #2132.
-- 🙌 Props of `<PascalCase>` components in templates will now be validated [@triforcely](https://github.com/triforcely). #2168.
+- 🙌 Validate props of `<PascalCase>` components in templates. Thanks to contribution from [@triforcely](https://github.com/triforcely). #2168.
 - 🙌 Add yarn@berry support and use `typescript.tsdk` setting for loading TypeScript in VLS. Thanks to contribution from [Alexandre Bonaventure Geissmann](https://github.com/AlexandreBonaventure). #1711, #1737 and #1996.
 - 🙌 Add support for analyzing vue-class-component and vue-property-decorator. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #864, #1105 and #1323.
 - 🙌 Remove lsp client-side commands to improve integration with third party lsp client. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2137.

--- a/server/src/modes/template/services/vuePropValidation.ts
+++ b/server/src/modes/template/services/vuePropValidation.ts
@@ -2,6 +2,7 @@ import { VueFileInfo } from '../../../services/vueInfoService';
 import { TextDocument, Diagnostic } from 'vscode-languageserver-types';
 import { HTMLDocument, Node } from '../parser/htmlParser';
 import { kebabCase } from 'lodash';
+import { getSameTagInSet } from '../tagProviders/common';
 
 export function doPropValidation(document: TextDocument, htmlDocument: HTMLDocument, info: VueFileInfo): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
@@ -14,10 +15,13 @@ export function doPropValidation(document: TextDocument, htmlDocument: HTMLDocum
   });
 
   traverseNodes(htmlDocument.roots, n => {
-    if (n.tag && Object.keys(childComponentToProps).includes(n.tag)) {
-      const d = generateDiagnostic(n, childComponentToProps[n.tag], document);
-      if (d) {
-        diagnostics.push(d);
+    if (n.tag) {
+      const foundTag = getSameTagInSet(childComponentToProps, n.tag);
+      if (foundTag) {
+        const d = generateDiagnostic(n, foundTag, document);
+        if (d) {
+          diagnostics.push(d);
+        }
       }
     }
   });

--- a/test/interpolation/features/diagnostics/propsValidation.test.ts
+++ b/test/interpolation/features/diagnostics/propsValidation.test.ts
@@ -9,29 +9,39 @@ describe('Should find common diagnostics for all regions', () => {
   it('shows errors for passing wrong props to child component', async () => {
     const expectedDiagnostics: vscode.Diagnostic[] = [
       {
-        message: '<child> misses props: foo, bar, b-az',
+        message: '<child-comp> misses props: foo, bar, b-az',
         severity: vscode.DiagnosticSeverity.Error,
-        range: sameLineRange(2, 4, 19)
+        range: sameLineRange(2, 4, 29)
       },
       {
-        message: '<child> misses props: bar, b-az',
+        message: '<child-comp> misses props: bar, b-az',
         severity: vscode.DiagnosticSeverity.Error,
-        range: sameLineRange(3, 4, 29)
+        range: sameLineRange(3, 4, 39)
       },
       {
-        message: '<child> misses props: bar, b-az',
+        message: '<child-comp> misses props: bar, b-az',
         severity: vscode.DiagnosticSeverity.Error,
-        range: sameLineRange(4, 4, 30)
+        range: sameLineRange(4, 4, 40)
       },
       {
-        message: '<child> misses props: b-az',
+        message: '<child-comp> misses props: b-az',
         severity: vscode.DiagnosticSeverity.Error,
-        range: sameLineRange(5, 4, 58)
+        range: sameLineRange(5, 4, 68)
       },
       {
-        message: '<child> misses props: b-az',
+        message: '<child-comp> misses props: b-az',
         severity: vscode.DiagnosticSeverity.Error,
-        range: sameLineRange(8, 4, 52)
+        range: sameLineRange(8, 4, 62)
+      },
+      {
+        message: '<ChildComp> misses props: foo, bar, b-az',
+        severity: vscode.DiagnosticSeverity.Error,
+        range: sameLineRange(9, 4, 17)
+      },
+      {
+        message: '<ChildComp> misses props: foo, bar, b-az',
+        severity: vscode.DiagnosticSeverity.Error,
+        range: sameLineRange(10, 4, 27)
       }
     ];
 

--- a/test/interpolation/fixture/diagnostics/propsValidation/parent.vue
+++ b/test/interpolation/fixture/diagnostics/propsValidation/parent.vue
@@ -1,21 +1,23 @@
 <template>
   <div>
-    <child></child>
-    <child foo="foo"></child>
-    <child :foo="foo"></child>
-    <child :foo="foo" :bar="bar" v-bind:baz="bar"></child>
-    <child :foo="foo" :bar="bar" :bAz="bar"></child>
-    <child :foo="foo" :bar="bar" :b-az="bar"></child>
-    <child :foo="foo" :bar="bar" :baz="bar"></child>
+    <child-comp></child-comp>
+    <child-comp foo="foo"></child-comp>
+    <child-comp :foo="foo"></child-comp>
+    <child-comp :foo="foo" :bar="bar" v-bind:baz="bar"></child-comp>
+    <child-comp :foo="foo" :bar="bar" :bAz="bar"></child-comp>
+    <child-comp :foo="foo" :bar="bar" :b-az="bar"></child-comp>
+    <child-comp :foo="foo" :bar="bar" :baz="bar"></child-comp>
+    <ChildComp />
+    <ChildComp></ChildComp>
   </div>
 </template>
 
 <script>
-import child from './child.vue'
+import ChildComp from './child.vue'
 
 export default {
   components: {
-    child
+    ChildComp
   },
   props: ['foo', 'bar']
 }


### PR DESCRIPTION
This PR fixes problem with 'PascalCase' component names in vue templates.