### PR TITLE
chore: use Vue's theme color for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
     <img src="https://vsmarketplacebadge.apphb.com/version-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=octref.vetur">
-    <img src="https://vsmarketplacebadge.apphb.com/installs-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
+    <img src="https://vsmarketplacebadge.apphb.com/installs-short/octref.vetur.svg?label=%20&style=flat-square&color=35495e">
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=octref.vetur">
-    <img src="https://vsmarketplacebadge.apphb.com/rating-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
+    <img src="https://vsmarketplacebadge.apphb.com/rating-short/octref.vetur.svg?label=%20&style=flat-square&color=35495e">
   </a>
   <br>
 </p>

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 <p align="center">
   <a href="https://github.com/vuejs/vetur/actions?query=workflow%3A%22Node+CI%22">
-    <img src="https://img.shields.io/github/workflow/status/vuejs/vetur/Node%20CI?label=%20&logo=github&style=flat-square&logoColor=black">
+    <img src="https://img.shields.io/github/workflow/status/vuejs/vetur/Node%20CI?label=%20&logo=github&style=flat-square&logoColor=white&color=42b883">
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=octref.vetur">
-    <img src="https://vsmarketplacebadge.apphb.com/version-short/octref.vetur.svg?label=%20&style=flat-square">
+    <img src="https://vsmarketplacebadge.apphb.com/version-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=octref.vetur">
-    <img src="https://vsmarketplacebadge.apphb.com/installs-short/octref.vetur.svg?label=%20&style=flat-square">
+    <img src="https://vsmarketplacebadge.apphb.com/installs-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=octref.vetur">
-    <img src="https://vsmarketplacebadge.apphb.com/rating-short/octref.vetur.svg?label=%20&style=flat-square">
+    <img src="https://vsmarketplacebadge.apphb.com/rating-short/octref.vetur.svg?label=%20&style=flat-square&color=42b883">
   </a>
   <br>
 </p>


### PR DESCRIPTION
<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->

The original "green" is a bit too saturated and having less contrast with the white text in my opinion. Not sure if you like the change though.

Using the Vue's color #42b883. Now it looks like this:

![image](https://user-images.githubusercontent.com/11247099/91515212-39b87480-e91b-11ea-8b02-01e53d706cdb.png)

Another idea might be to use the other color #35495e together, which is not part of this PR. If you like it, I can change to it for sure :)
![image](https://user-images.githubusercontent.com/11247099/91515506-ee529600-e91b-11ea-8020-c0967e130dcf.png)
