### PR TITLE
Add line break in JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - 🙌 Fix "Go to definition" for methods/computed does not work in the template. Thanks to contribution from [@cereschen](https://github.com/cereschen). #1484 and #2161.
 - 🙌 Prop with `required: false` or default value should not trigger prop validation error when not provided. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2141.
 - 🙌 Show slot-related tag attributes in symbol search. Thanks to contribution from [@3nuc](https://github.com/3nuc). #2169
+- 🙌 Fix JSDoc presentation had no line breaks. Thanks to contribution from [@sapphi-red](https://github.com/sapphi-red). #2214.
 
 ### 0.26.1 | 2020-08-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.26.1/vspackage)
 

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -241,7 +241,7 @@ export async function getJavascriptMode(
             details.tags.forEach(x => {
               const tagDoc = Previewer.getTagDocumentation(x);
               if (tagDoc) {
-                documentation.value += tagDoc;
+                documentation.value += tagDoc + '\n\n';
               }
             });
           }
@@ -284,7 +284,7 @@ export async function getJavascriptMode(
           info.tags.forEach(x => {
             const tagDoc = Previewer.getTagDocumentation(x);
             if (tagDoc) {
-              hoverMdDoc += tagDoc;
+              hoverMdDoc += tagDoc + '\n\n';
             }
           });
         }
@@ -338,7 +338,7 @@ export async function getJavascriptMode(
           .forEach(x => {
             const tagDoc = Previewer.getTagDocumentation(x);
             if (tagDoc) {
-              sigMdDoc += tagDoc;
+              sigMdDoc += tagDoc + '\n\n';
             }
           });
 

--- a/server/src/modes/template/interpolationMode.ts
+++ b/server/src/modes/template/interpolationMode.ts
@@ -218,7 +218,7 @@ export class VueInterpolationMode implements LanguageMode {
           details.tags.forEach(x => {
             const tagDoc = Previewer.getTagDocumentation(x);
             if (tagDoc) {
-              documentation.value += tagDoc;
+              documentation.value += tagDoc + '\n\n';
             }
           });
         }
@@ -274,7 +274,7 @@ export class VueInterpolationMode implements LanguageMode {
         info.tags.forEach(x => {
           const tagDoc = Previewer.getTagDocumentation(x);
           if (tagDoc) {
-            hoverMdDoc += tagDoc;
+            hoverMdDoc += tagDoc + '\n\n';
           }
         });
       }


### PR DESCRIPTION
In `.ts` file, VSCode shows JSDoc in multiple lines.
![image](https://user-images.githubusercontent.com/49056869/91659177-56b29a80-eb09-11ea-95bf-1976317768f6.png)

So I changed it to make Vetur acts the same.

## Before
![image](https://user-images.githubusercontent.com/49056869/91659145-15ba8600-eb09-11ea-9169-90a67ab3f545.png)
![image](https://user-images.githubusercontent.com/49056869/91659155-2ec33700-eb09-11ea-8fef-9e57dd02c4e4.png)

## After
![image](https://user-images.githubusercontent.com/49056869/91659117-cb390980-eb08-11ea-878d-3e297a0a3057.png)
![image](https://user-images.githubusercontent.com/49056869/91659126-df7d0680-eb08-11ea-82e8-04966b832aeb.png)

refs b88a39d e21fe22

This PR includes a user-facing change but it does not affect most users, since this change is based on a unreleased change.
Should I update `CHANGELOG.md`?
