### PR TITLE
Performance optimization: merge languageService

### DIFF
--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -45,6 +45,7 @@ import { RefactorAction } from '../../types';
 import { IServiceHost } from '../../services/typescriptService/serviceHost';
 import { toCompletionItemKind, toSymbolKind } from '../../services/typescriptService/util';
 import * as Previewer from './previewer';
+import { sourceFileNameSet } from '../../services/typescriptService/preprocess';
 
 // Todo: After upgrading to LS server 4.0, use CompletionContext for filtering trigger chars
 // https://microsoft.github.io/language-server-protocol/specification#completion-request-leftwards_arrow_with_hook
@@ -109,7 +110,7 @@ export async function getJavascriptMode(
 
     doValidation(doc: TextDocument): Diagnostic[] {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -140,7 +141,7 @@ export async function getJavascriptMode(
     },
     doComplete(doc: TextDocument, position: Position): CompletionList {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return { isIncomplete: false, items: [] };
       }
 
@@ -212,7 +213,7 @@ export async function getJavascriptMode(
     },
     doResolve(doc: TextDocument, item: CompletionItem): CompletionItem {
       const { service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return item;
       }
 
@@ -264,7 +265,7 @@ export async function getJavascriptMode(
     },
     doHover(doc: TextDocument, position: Position): Hover {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return { contents: [] };
       }
 
@@ -302,7 +303,7 @@ export async function getJavascriptMode(
     },
     doSignatureHelp(doc: TextDocument, position: Position): SignatureHelp | null {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return NULL_SIGNATURE;
       }
 
@@ -360,7 +361,7 @@ export async function getJavascriptMode(
     },
     findDocumentHighlight(doc: TextDocument, position: Position): DocumentHighlight[] {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -378,7 +379,7 @@ export async function getJavascriptMode(
     },
     findDocumentSymbols(doc: TextDocument): SymbolInformation[] {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -418,7 +419,7 @@ export async function getJavascriptMode(
     },
     findDefinition(doc: TextDocument, position: Position): Definition {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -444,7 +445,7 @@ export async function getJavascriptMode(
     },
     findReferences(doc: TextDocument, position: Position): Location[] {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -472,7 +473,7 @@ export async function getJavascriptMode(
     },
     getFoldingRanges(doc) {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
-      if (!languageServiceIncludesFile(service, doc.uri)) {
+      if (!languageServiceIncludesFile(doc.uri)) {
         return [];
       }
 
@@ -718,10 +719,8 @@ function getSourceDoc(fileName: string, program: ts.Program): TextDocument {
   return TextDocument.create(fileName, 'vue', 0, sourceFile.getFullText());
 }
 
-export function languageServiceIncludesFile(ls: ts.LanguageService, documentUri: string): boolean {
-  const filePaths = ls.getProgram()!.getRootFileNames();
-  const filePath = getFilePath(documentUri);
-  return filePaths.includes(filePath);
+export function languageServiceIncludesFile(documentUri: string): boolean {
+  return sourceFileNameSet.has(getFilePath(documentUri));
 }
 
 function convertRange(document: TextDocument, span: ts.TextSpan): Range {

--- a/server/src/modes/template/interpolationMode.ts
+++ b/server/src/modes/template/interpolationMode.ts
@@ -78,7 +78,7 @@ export class VueInterpolationMode implements LanguageMode {
       childComponents
     );
 
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return [];
     }
 
@@ -123,7 +123,7 @@ export class VueInterpolationMode implements LanguageMode {
     );
 
     const { templateService, templateSourceMap } = this.serviceHost.updateCurrentVirtualVueTextDocument(templateDoc);
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return NULL_COMPLETION;
     }
 
@@ -213,7 +213,7 @@ export class VueInterpolationMode implements LanguageMode {
     );
 
     const { templateService, templateSourceMap } = this.serviceHost.updateCurrentVirtualVueTextDocument(templateDoc);
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return item;
     }
 
@@ -274,7 +274,7 @@ export class VueInterpolationMode implements LanguageMode {
     );
 
     const { templateService, templateSourceMap } = this.serviceHost.updateCurrentVirtualVueTextDocument(templateDoc);
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return {
         contents: []
       };
@@ -329,7 +329,7 @@ export class VueInterpolationMode implements LanguageMode {
     );
 
     const { templateService, templateSourceMap } = this.serviceHost.updateCurrentVirtualVueTextDocument(templateDoc);
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return [];
     }
 
@@ -377,7 +377,7 @@ export class VueInterpolationMode implements LanguageMode {
     );
 
     const { templateService, templateSourceMap } = this.serviceHost.updateCurrentVirtualVueTextDocument(templateDoc);
-    if (!languageServiceIncludesFile(templateService, templateDoc.uri)) {
+    if (!languageServiceIncludesFile(templateDoc.uri)) {
       return [];
     }
 

--- a/server/src/services/typescriptService/preprocess.ts
+++ b/server/src/services/typescriptService/preprocess.ts
@@ -21,6 +21,8 @@ import { kebabCase, snakeCase } from 'lodash';
 
 const importedComponentName = '__vlsComponent';
 
+export const sourceFileNameSet = new Set();
+
 export function parseVueScript(text: string): string {
   const doc = TextDocument.create('test://test/test.vue', 'vue', 0, text);
   const regions = getVueDocumentRegions(doc);
@@ -140,6 +142,7 @@ export function createUpdater(tsModule: T_TypeScript, allChildComponentsInfo: Ma
     scriptKind?: ts.ScriptKind
   ): ts.SourceFile {
     let sourceFile = clssf(fileName, scriptSnapshot, scriptTarget, version, setNodeParents, scriptKind);
+    sourceFileNameSet.add(fileName);
     scriptKindTracker.set(sourceFile, scriptKind);
     if (isVirtualVueTemplateFile(fileName)) {
       sourceFile = recreateVueTemplateSourceFile(fileName, sourceFile, scriptSnapshot);

--- a/server/src/services/typescriptService/serviceHost.ts
+++ b/server/src/services/typescriptService/serviceHost.ts
@@ -420,8 +420,8 @@ export function getServiceHost(
   });
 
   const registry = tsModule.createDocumentRegistry(true);
-  let jsLanguageService = tsModule.createLanguageService(jsHost, registry);
-  const templateLanguageService = patchTemplateService(tsModule.createLanguageService(templateHost, registry));
+  let jsLanguageService = patchTemplateService(tsModule.createLanguageService(jsHost, registry));
+  const templateLanguageService = jsLanguageService;
 
   return {
     queryVirtualFileInfo,
@@ -442,6 +442,11 @@ function patchTemplateService(original: ts.LanguageService): ts.LanguageService 
 
     getCompletionsAtPosition(fileName, position, options) {
       const result = original.getCompletionsAtPosition(fileName, position, options);
+
+      if (!fileName.endsWith('template')) {
+        return result;
+      }
+
       if (!result) {
         return;
       }

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -537,11 +537,7 @@ export class VLS {
     if (doc.languageId === 'vue') {
       this.languageModes.getAllLanguageModeRangesInDocument(doc).forEach(lmr => {
         if (lmr.mode.doValidation) {
-          if (this.validation[lmr.mode.getId()]) {
-            pushAll(diagnostics, lmr.mode.doValidation(doc));
-          }
-          // Special case for template type checking
-          else if (lmr.mode.getId() === 'vue-html' && this.templateInterpolationValidation) {
+          if (this.validation[lmr.mode.getId()] && lmr.mode.getId() !== 'vue-html') {
             pushAll(diagnostics, lmr.mode.doValidation(doc));
           }
         }


### PR DESCRIPTION
Use a Set to save filenames, it's can save about 100ms.

 The only difference between templateLanguageService and  jsLanguageService  is getCompletionsAtPosition.

But in every time doValidate and others  takes twice as long,merge them will greatly reduce waiting times

Now I only do doValidate(the function which wasting a lot of time saving files) part, if you pass the test, you can modify the other parts