### PR TITLE
changed warming to warning

### DIFF
--- a/docs/interpolation.md
+++ b/docs/interpolation.md
@@ -117,7 +117,7 @@ export default {
 </script>
 ```
 
-Vetur will show a warming for `<simple>` and an error for `<complex>`.
+Vetur will show a warning for `<simple>` and an error for `<complex>`.
 
 The rules are:
 


### PR DESCRIPTION
Changed this line: Vetur will show a **warming** for `<simple>` and an error for `<complex>`.

To this line: Vetur will show a **warning** for `<simple>` and an error for `<complex>`.