### PR TITLE
Fix invalid client/registerCapability request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.29.1
 
-- Fix invalid `client/registerCapability` request. Thanks to contribution from [@rchl](https://github.com/rchl) #2388
+- 🙌 Fix invalid `client/registerCapability` request. Thanks to contribution from [@rchl](https://github.com/rchl). #2388.
 
 ### 0.29.0 | 2020-11-02 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.29.0/vspackage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.29.1
+
+- Fix invalid `client/registerCapability` request. Thanks to contribution from [@rchl](https://github.com/rchl) #2388
+
 ### 0.29.0 | 2020-11-02 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.29.0/vspackage)
 
 - Fix "Duplicate identifier" errors when using multiple keydown events with modifiers. #1745.

--- a/client/client.ts
+++ b/client/client.ts
@@ -12,7 +12,7 @@ import { existsSync } from 'fs';
 export function initializeLanguageClient(vlsModulePath: string, globalSnippetDir: string): LanguageClient {
   const debugOptions = { execArgv: ['--nolazy', '--inspect=6005'] };
 
-  const documentSelector = ['vue'];
+  const documentSelector = [{ language: 'vue' }];
   const config = vscode.workspace.getConfiguration();
 
   let serverPath;

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -191,7 +191,7 @@ export class VLS {
     if (settings.vetur.format.enable) {
       if (!this.documentFormatterRegistration) {
         this.documentFormatterRegistration = await this.lspConnection.client.register(DocumentFormattingRequest.type, {
-          documentSelector: ['vue']
+          documentSelector: [{ language: 'vue' }]
         });
       }
     } else {


### PR DESCRIPTION

Per current version of the spec [1], the "documentSelector" is a list of
DocumentFilter and can not contain a string.

It seems like it was allowed to have a string in the past [2] but it's
no longer the case and it doesn't work even in VSCode.

[1] https://microsoft.github.io/language-server-protocol/specification#documentFilter
[2] https://github.com/microsoft/vscode-languageserver-node/issues/685

Resolves #2388