### PR TITLE
Fix issue with "File name X differs from already included" on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 0.29.1
 
-- 🙌 Fix invalid `client/registerCapability` request. Thanks to contribution from [@rchl](https://github.com/rchl). #2388.
+- 🙌 Fix invalid `client/registerCapability` request. Thanks to contribution from [@rchl](https://github.com/rchl). #2388 and #2388.
+- 🙌 Fix "File name X differs from already included file name Y only in casing" on Windows. Thanks to contribution from [@rchl](https://github.com/rchl). #2433 and #2444.
 
 ### 0.29.0 | 2020-11-02 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.29.0/vspackage)
 

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { getFileFsPath } from '../utils/paths';
+import { getFileFsPath, normalizeFileNameToFsPath } from '../utils/paths';
 
 import {
   DidChangeConfigurationParams,
@@ -104,13 +104,17 @@ export class VLS {
       };
     }
 
-    this.workspacePath = workspacePath;
+    this.workspacePath = normalizeFileNameToFsPath(workspacePath);
 
     this.vueInfoService.init(this.languageModes);
-    await this.dependencyService.init(workspacePath, config.vetur.useWorkspaceDependencies, config.typescript.tsdk);
+    await this.dependencyService.init(
+      this.workspacePath,
+      config.vetur.useWorkspaceDependencies,
+      config.typescript.tsdk
+    );
 
     await this.languageModes.init(
-      workspacePath,
+      this.workspacePath,
       {
         infoService: this.vueInfoService,
         dependencyService: this.dependencyService

--- a/test/interpolation/path.ts
+++ b/test/interpolation/path.ts
@@ -2,7 +2,7 @@ import { Uri } from 'vscode';
 import { resolve } from 'path';
 
 export const getDocPath = (p: string) => {
-  return resolve(__dirname, `../../../test/interpolation/fixture`, p);
+  return Uri.file(resolve(__dirname, `../../../test/interpolation/fixture`, p)).fsPath;
 };
 export const getDocUri = (p: string) => {
   return Uri.file(getDocPath(p));


### PR DESCRIPTION
On Sublime Text (and potentially other clients) the paths passed to
LSP servers on Windows have an upper-case drive letter. So either:
 - `C:\folder\foo`
 or
 - `file:///C:/folder/foo`

This is problematic with Vetur as it normalizes URI paths received from
the client in notifications and requests like "textDocument/completion",
"textDocument/didChange" etc. It uses `getFileFsPath()` utility path to
get a filesystem path from the URI.

But it doesn't do normalization for the filesystem path received through
`InitializeParams.rootPath` and then uses that path to initialize the
Typescript server. That list (`parsedConfig.fileNames` in `serviceHost.ts`)
is later used to lookup files passed through other calls and causes
issues due to there being duplicate path differing only with drive letter.

This issue doesn't reproduce in VSCode as it itself normalizes paths
passed to the server and automatically lower-cases the drive letter.

Fix by normalizing the path passed through `InitializeParams.rootPath`.

Fixes #2433

<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->