### PR TITLE
feat: add Yarn PnP support

### DIFF
--- a/server/src/modes/template/tagProviders/externalTagProviders.ts
+++ b/server/src/modes/template/tagProviders/externalTagProviders.ts
@@ -52,10 +52,13 @@ export function getDependencyTagProvider(workspacePath: string, depPkgJson: any)
     return null;
   }
 
-  const tagsPath = findConfigFile(workspacePath, path.join('node_modules/', depPkgJson.name, depPkgJson.vetur.tags));
+  const tagsPath = findConfigFile(
+    workspacePath,
+    require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.tags), { paths: [workspacePath] })
+  );
   const attrsPath = findConfigFile(
     workspacePath,
-    path.join('node_modules/', depPkgJson.name, depPkgJson.vetur.attributes)
+    require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.attributes), { paths: [workspacePath] })
   );
 
   try {

--- a/server/src/modes/template/tagProviders/externalTagProviders.ts
+++ b/server/src/modes/template/tagProviders/externalTagProviders.ts
@@ -52,18 +52,15 @@ export function getDependencyTagProvider(workspacePath: string, depPkgJson: any)
     return null;
   }
 
-  const tagsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.tags), { paths: [workspacePath] });
-  const attrsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.attributes), {
-    paths: [workspacePath]
-  });
-
   try {
-    if (tagsPath && attrsPath) {
-      const tagsJson = JSON.parse(fs.readFileSync(tagsPath, 'utf-8'));
-      const attrsJson = JSON.parse(fs.readFileSync(attrsPath, 'utf-8'));
-      return getExternalTagProvider(depPkgJson.name, tagsJson, attrsJson);
-    }
-    return null;
+    const tagsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.tags), { paths: [workspacePath] });
+    const attrsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.attributes), {
+      paths: [workspacePath]
+    });
+
+    const tagsJson = JSON.parse(fs.readFileSync(tagsPath, 'utf-8'));
+    const attrsJson = JSON.parse(fs.readFileSync(attrsPath, 'utf-8'));
+    return getExternalTagProvider(depPkgJson.name, tagsJson, attrsJson);
   } catch (err) {
     return null;
   }

--- a/server/src/modes/template/tagProviders/externalTagProviders.ts
+++ b/server/src/modes/template/tagProviders/externalTagProviders.ts
@@ -52,14 +52,10 @@ export function getDependencyTagProvider(workspacePath: string, depPkgJson: any)
     return null;
   }
 
-  const tagsPath = findConfigFile(
-    workspacePath,
-    require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.tags), { paths: [workspacePath] })
-  );
-  const attrsPath = findConfigFile(
-    workspacePath,
-    require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.attributes), { paths: [workspacePath] })
-  );
+  const tagsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.tags), { paths: [workspacePath] });
+  const attrsPath = require.resolve(path.join(depPkgJson.name, depPkgJson.vetur.attributes), {
+    paths: [workspacePath]
+  });
 
   try {
     if (tagsPath && attrsPath) {

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -115,7 +115,10 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     }
 
     for (const dep of [...Object.keys(dependencies), ...Object.keys(devDependencies)]) {
-      const runtimePkgJsonPath = findConfigFile(workspacePath, join('node_modules', dep, 'package.json'));
+      const runtimePkgJsonPath = findConfigFile(
+        workspacePath,
+        require.resolve(join(dep, 'package.json'), { paths: [workspacePath] })
+      );
 
       if (!runtimePkgJsonPath) {
         continue;

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -115,10 +115,7 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     }
 
     for (const dep of [...Object.keys(dependencies), ...Object.keys(devDependencies)]) {
-      const runtimePkgJsonPath = findConfigFile(
-        workspacePath,
-        require.resolve(join(dep, 'package.json'), { paths: [workspacePath] })
-      );
+      const runtimePkgJsonPath = require.resolve(join(dep, 'package.json'), { paths: [workspacePath] });
 
       if (!runtimePkgJsonPath) {
         continue;

--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -115,9 +115,10 @@ export function getTagProviderSettings(workspacePath: string | null | undefined)
     }
 
     for (const dep of [...Object.keys(dependencies), ...Object.keys(devDependencies)]) {
-      const runtimePkgJsonPath = require.resolve(join(dep, 'package.json'), { paths: [workspacePath] });
-
-      if (!runtimePkgJsonPath) {
+      let runtimePkgJsonPath;
+      try {
+        runtimePkgJsonPath = require.resolve(join(dep, 'package.json'), { paths: [workspacePath] });
+      } catch {
         continue;
       }
 

--- a/server/src/services/typescriptService/vueVersion.ts
+++ b/server/src/services/typescriptService/vueVersion.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import path from 'path';
 import { findConfigFile } from '../../utils/workspace';
 
 export enum VueVersion {
@@ -31,10 +30,7 @@ export function inferVueVersion(workspacePath: string): VueVersion {
       return floatVersionToEnum(sloppyVersion);
     }
 
-    const nodeModulesVuePackagePath = findConfigFile(
-      workspacePath,
-      require.resolve('vue/package.json', { paths: [workspacePath] })
-    );
+    const nodeModulesVuePackagePath = require.resolve('vue/package.json', { paths: [workspacePath] });
     const nodeModulesVuePackageJSON =
       nodeModulesVuePackagePath && JSON.parse(readFileSync(nodeModulesVuePackagePath, { encoding: 'utf-8' })!);
     const nodeModulesVueVersion = parseFloat(nodeModulesVuePackageJSON.version.match(/\d+\.\d+/)[0]);

--- a/server/src/services/typescriptService/vueVersion.ts
+++ b/server/src/services/typescriptService/vueVersion.ts
@@ -31,8 +31,7 @@ export function inferVueVersion(workspacePath: string): VueVersion {
     }
 
     const nodeModulesVuePackagePath = require.resolve('vue/package.json', { paths: [workspacePath] });
-    const nodeModulesVuePackageJSON =
-      nodeModulesVuePackagePath && JSON.parse(readFileSync(nodeModulesVuePackagePath, { encoding: 'utf-8' })!);
+    const nodeModulesVuePackageJSON = JSON.parse(readFileSync(nodeModulesVuePackagePath, { encoding: 'utf-8' })!);
     const nodeModulesVueVersion = parseFloat(nodeModulesVuePackageJSON.version.match(/\d+\.\d+/)[0]);
 
     return floatVersionToEnum(nodeModulesVueVersion);

--- a/server/src/services/typescriptService/vueVersion.ts
+++ b/server/src/services/typescriptService/vueVersion.ts
@@ -31,7 +31,10 @@ export function inferVueVersion(workspacePath: string): VueVersion {
       return floatVersionToEnum(sloppyVersion);
     }
 
-    const nodeModulesVuePackagePath = findConfigFile(path.resolve(workspacePath, 'node_modules/vue'), 'package.json');
+    const nodeModulesVuePackagePath = findConfigFile(
+      workspacePath,
+      require.resolve('vue/package.json', { paths: [workspacePath] })
+    );
     const nodeModulesVuePackageJSON =
       nodeModulesVuePackagePath && JSON.parse(readFileSync(nodeModulesVuePackagePath, { encoding: 'utf-8' })!);
     const nodeModulesVueVersion = parseFloat(nodeModulesVuePackageJSON.version.match(/\d+\.\d+/)[0]);

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -107,8 +107,8 @@ export class VLS {
 
     this.workspacePath = normalizeFileNameToFsPath(workspacePath);
 
-    // Enable PnP API
-    if (this.workspacePath && !process.versions.pnp && config.vetur.useWorkspaceDependencies) {
+    // Enable Yarn PnP support https://yarnpkg.com/features/pnp
+    if (!process.versions.pnp) {
       if (fs.existsSync(path.join(this.workspacePath, '.pnp.js'))) {
         require(path.join(workspacePath, '.pnp.js')).setup();
       } else if (fs.existsSync(path.join(this.workspacePath, '.pnp.cjs'))) {

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import { getFileFsPath, normalizeFileNameToFsPath } from '../utils/paths';
 
 import {
@@ -105,6 +106,15 @@ export class VLS {
     }
 
     this.workspacePath = normalizeFileNameToFsPath(workspacePath);
+
+    // Enable PnP API
+    if (this.workspacePath && !process.versions.pnp && config.vetur.useWorkspaceDependencies) {
+      if (fs.existsSync(path.join(this.workspacePath, '.pnp.js'))) {
+        require(path.join(workspacePath, '.pnp.js')).setup();
+      } else if (fs.existsSync(path.join(this.workspacePath, '.pnp.cjs'))) {
+        require(path.join(workspacePath, '.pnp.cjs')).setup();
+      }
+    }
 
     this.vueInfoService.init(this.languageModes);
     await this.dependencyService.init(


### PR DESCRIPTION
**What's the problem this PR addresses?**

The tag providers can't be located under Yarn PnP due to hard coding `node_modules`

Fixes https://github.com/vuejs/vetur/issues/2469

**How did you fix it?**

- Use require.resolve to locate tag providers
- Setup the PnP hook from the workspace if it exists