### PR TITLE
docs(): add ionic framework vetur support

### DIFF
--- a/docs/component-data.md
+++ b/docs/component-data.md
@@ -23,6 +23,7 @@ Vetur currently bundles Component Data for the following vue libraries:
 - [Vuetify](https://vuetifyjs.com/en/)
 - [Quasar Framework](https://quasar.dev/)
 - [Gridsome](https://gridsome.org/)
+- [Ionic Framework](https://ionicframework.com/)
 
 Vetur reads the `package.json` **in your project root** to determine if it should offer tags & attributes completions. Here are the exact `dependencies`/`devDependencies` used to determine which Component Data to load.
 
@@ -38,6 +39,7 @@ Vetur reads the `package.json` **in your project root** to determine if it shoul
 | `nuxt` | `nuxt` | Bundled in [@nuxt/vue-app](https://www.npmjs.com/package/@nuxt/vue-app) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) with [@nuxt/components](https://github.com/nuxt/components) integration |
 | `nuxt-edge` | `nuxt-edge` | Bundled in [@nuxt/vue-app-edge](https://www.npmjs.com/package/@nuxt/vue-app-edge) package, or fallback to [nuxt-helper-json](https://github.com/nuxt-community/nuxt-helper-json) with [@nuxt/components](https://github.com/nuxt/components) integration |
 | `quasar` / `quasar-framework` | `quasar` / `quasar-cli` | Bundled in [quasar](https://www.npmjs.com/package/quasar) (v1+) and [quasar-framework](https://www.npmjs.com/package/quasar-framework) (pre v1) packages |
+| `@ionic/vue` | `@ionic/vue` | Bundled in [@ionic/vue](https://www.npmjs.com/package/@ionic/vue) (v5.5.0+) |
 
 Getting `element-ui`'s completions is as easy as running `yarn add element-ui` and reloading VS Code.
 


### PR DESCRIPTION
<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->

Hey there,

Ionic Framework recently released Vetur support for the Vue 3 integration in our v5.5.0 release. We would love it if we could get listed on the "Supported Frameworks" section.

Thanks!