### PR TITLE
sort attribute suggestion without `:` or `@`

### DIFF
--- a/server/src/modes/template/services/htmlCompletion.ts
+++ b/server/src/modes/template/services/htmlCompletion.ts
@@ -168,12 +168,14 @@ export function doComplete(
         if ((filterPrefix === ':' && codeSnippet[0] === ':') || (filterPrefix === '@' && codeSnippet[0] === '@')) {
           codeSnippet = codeSnippet.slice(1);
         }
+        const trimedName = attribute.replace(/^(?::|@)/, '');
         result.items.push({
           label: attribute,
           kind: type === 'event' ? CompletionItemKind.Function : CompletionItemKind.Value,
           textEdit: TextEdit.replace(range, codeSnippet),
           insertTextFormat: InsertTextFormat.Snippet,
-          sortText: priority + attribute,
+          sortText: priority + trimedName,
+          filterText: trimedName,
           documentation: toMarkupContent(documentation)
         });
       });


### PR DESCRIPTION
This PR changes `sortText` and `filterText` of completion to make custom attributes more likely to come at the top.

### before
![image](https://user-images.githubusercontent.com/49056869/101877770-e28c9600-3bd1-11eb-8fdc-8b5a2dce644f.png)

### after
![image](https://user-images.githubusercontent.com/49056869/101877890-094acc80-3bd2-11eb-85e9-ab6414fc9ea3.png)

refs #2309
