### PR TITLE
Dont include used attributes in suggestions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+server/src/modes/template/test/completion.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 🙌 Remove used attributes from suggestions. Thanks to contribution from [@sapphi-red](https://github.com/sapphi-red).
+
 ### 0.31.3 | 2020-12-13 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.31.3/vspackage)
 
 - Console error only message when unimportant.

--- a/server/src/modes/template/services/htmlCompletion.ts
+++ b/server/src/modes/template/services/htmlCompletion.ts
@@ -150,7 +150,7 @@ export function doComplete(
 
   function getUsedAttributes(offset: number) {
     const node = htmlDocument.findNodeBefore(offset);
-    return node.attributeNames.map(normalizeAttributeNameToKebabCase);
+    return new Set(node.attributeNames.map(normalizeAttributeNameToKebabCase));
   }
 
   function collectAttributeNameSuggestions(nameStart: number, nameEnd: number = offset): CompletionList {
@@ -174,7 +174,7 @@ export function doComplete(
           // `class` and `:class`, `style` and `:style` can coexist
           attribute !== 'class' &&
           attribute !== 'style' &&
-          usedAttributes.includes(normalizeAttributeNameToKebabCase(attribute))
+          usedAttributes.has(normalizeAttributeNameToKebabCase(attribute))
         ) {
           return;
         }

--- a/server/src/modes/template/test/completion.test.ts
+++ b/server/src/modes/template/test/completion.test.ts
@@ -77,24 +77,21 @@ suite('HTML Completion', () => {
       .become('<input tabindex="$1"');
 
     html`<input t|ype="text"`
-      .has('type')
-      .become('<input type="text"')
+      .hasNo('type')
       .has('tabindex')
       .become('<input tabindex="text"');
 
     html`<input type="text" |`
       .has('style')
       .become('<input type="text" style="$1"')
-      .has('type')
-      .become('<input type="text" type="$1"')
+      .hasNo('type')
       .has('size')
       .become('<input type="text" size="$1"');
 
     html`<input type="text" s|`
       .has('style')
       .become('<input type="text" style="$1"')
-      .has('type')
-      .become('<input type="text" type="$1"')
+      .hasNo('type')
       .has('size')
       .become('<input type="text" size="$1"');
 
@@ -114,7 +111,19 @@ suite('HTML Completion', () => {
 
     html`<input :di| type="text"`.has('dir').become('<input :dir="$1" type="text"');
 
+    html`<input :type="type" |`.hasNo('type');
+
+    html`<input :type.prop="type" |`.hasNo('type');
+
+    // `class` and `:class`, `style` and `:style` can coexist
+    html`<input :class="$style.input" |`.has('class');
+    html`<input style="style" |`.has('style');
+    html`<input :cl|ass="$style.input"`.has('class').become('<input :class="$style.input"');
+
     html`<input @|`.has('mousemove').become('<input @mousemove="$1"');
+
+    // can listen to same event by adding modifiers
+    html`<input @mousemove="mousemove" @|`.has('mousemove').become('<input @mousemove="mousemove" @mousemove="$1"');
   });
 
   test('Complete Value', () => {

--- a/test/interpolation/features/completion/property.test.ts
+++ b/test/interpolation/features/completion/property.test.ts
@@ -93,7 +93,7 @@ describe('Should autocomplete interpolation for <template> in property class com
     ];
 
     it(`completes child component's props`, async () => {
-      await testCompletion(parentTemplateDocUri, position(2, 27), propsList);
+      await testCompletion(parentTemplateDocUri, position(2, 26), propsList);
     });
 
     it(`completes child component's props when camel case component name`, async () => {

--- a/test/interpolation/fixture/completion/propertyDecorator/Parent.vue
+++ b/test/interpolation/fixture/completion/propertyDecorator/Parent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <basic-property-class :foo=""></basic-property-class>
+    <basic-property-class ></basic-property-class>
     <basic-property-class v-if="" @click="" :foo=""></basic-property-class>
     <BasicPropertyClass  />
     <


### PR DESCRIPTION
This PR removes used attributes from suggestions except

- it is `class` , because `:class` and `class` can coexist (same with `style`)
  - https://eslint.vuejs.org/rules/no-duplicate-attributes.html
- it is a event listener, because it is able to listen to same event by adding modifiers
