### PR TITLE
(dev) fix building in directory that has space in the path

### DIFF
--- a/build/rollup-plugins.js
+++ b/build/rollup-plugins.js
@@ -31,7 +31,7 @@ function generateTypingsVls() {
     buildStart() {
       return new Promise((resolve, reject) => {
         const tsc = spawn(
-          getServerPath('node_modules/.bin/tsc'),
+          path.join('node_modules', '.bin', 'tsc'),
           ['--declaration', '--declarationDir', './typings', '--emitDeclarationOnly', '--pretty'],
           { cwd: getServerPath('./'), shell: true }
         );


### PR DESCRIPTION
<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->

The server building would fail on a directory that has space in the path, for example: `c:/my projects/vetur`. Because the spawn of a child process of `tsc` uses the full path as a command like `c:/my projects/vetur/node_modules/.bin/tsc`. 