### PR TITLE
Upgrade stylus-supremacy from 2.14.5 to 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.32.1
+
+- Upgrade `stylus-supremacy` to 2.15.0
+
 ### 0.32.0 | 2021-01-21 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.32.0/vspackage)
 
 - Upgrade LSP to 3.16
@@ -41,10 +45,10 @@
 
 #### 🎉 RFC release 🎉
 
-We support monorepo and multi-root workspace in this version.   
-We have also added a new config file called `vetur.config.js`.   
+We support monorepo and multi-root workspace in this version.
+We have also added a new config file called `vetur.config.js`.
 
-See more: https://vuejs.github.io/vetur/guide/setup.html#advanced   
+See more: https://vuejs.github.io/vetur/guide/setup.html#advanced
 Reference: https://vuejs.github.io/vetur/reference/
 
 ----
@@ -88,10 +92,10 @@ Reference: https://vuejs.github.io/vetur/reference/
 ----
 
 #### ⚠️  Breaking change: ⚠️
-The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.   
+The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.
 Like `prettier`, `@prettier/plugin-pug`.
 
-In this version, we try to bundle extension and reduce size. (70MB -> 9MB)   
+In this version, we try to bundle extension and reduce size. (70MB -> 9MB)
 But it's a huge change, so please open an issue if you find any problems.
 
 ----
@@ -644,11 +648,11 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Always ignore `end_with_newline` option in js-beautify so the template formats properly. #544.
 
 
-### 0.11.3 | 2017-11-13 
+### 0.11.3 | 2017-11-13
 
 - Hot fix for a bug in formatting `<template>` with js-beautify where it adds `</template>` to the end. #539.
 
-### 0.11.2 | 2017-11-13 
+### 0.11.2 | 2017-11-13
 
 - Workaround a js-beautify bug which indents multi-line comment. #535.
 - Docs for generating grammar for custom blocks: https://vuejs.github.io/vetur/highlighting.html.
@@ -656,7 +660,7 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Disallow longer version of `lang` in custom block setting (`js` over `javascript`, `md` over `markdown`).
 - Pretty print generated gramamr so it's readable. (You can find it at `~/.vscode/extensions/octref.vetur-<version>./syntaxes/vue-generated.json`).
 
-### 0.11.1 | 2017-11-10 
+### 0.11.1 | 2017-11-10
 
 - Syntax highlighting for Custom Block. #210.
   - Added setting `vetur.grammar.customBlocks`.

--- a/server/package.json
+++ b/server/package.json
@@ -64,7 +64,7 @@
     "sass-formatter": "^0.7.0",
     "source-map-support": "^0.5.19",
     "stylus": "^0.54.8",
-    "stylus-supremacy": "^2.14.5",
+    "stylus-supremacy": "^2.15.0",
     "vscode-css-languageservice": "5.0.3",
     "vscode-emmet-helper": "2.2.4-2",
     "vscode-languageserver": "7.0.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2517,6 +2517,14 @@ js-yaml@3.14.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -4122,15 +4130,15 @@ stylint@^2.0.0:
     user-home "2.0.0"
     yargs "4.7.1"
 
-stylus-supremacy@^2.14.5:
-  version "2.14.5"
-  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.14.5.tgz#47b723d160768d3679aeaa195e94cc85f34f51fa"
-  integrity sha512-JZjCn4GxPhghgAZ7cdYOKjbo9LIU42BcksNCeLgWQa2FtjyEz44mKKnaXVgUYw+AQIm+x/MblV+VJ04Yk5DSqw==
+stylus-supremacy@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/stylus-supremacy/-/stylus-supremacy-2.15.0.tgz#d802ea3c3f8aa1d0f1fcaf6fd4aeda2a461bb29d"
+  integrity sha512-XXfA33wxC8xQ0rW9WpA0MOuLOLuzmVsDUmdI1qyKiafJmg1+oqn/efMbtTxUKDgk13DGqNqUgCPhkS16g5T7Qw==
   dependencies:
     glob "^7.1.6"
-    js-yaml "^3.13.1"
+    js-yaml "^3.14.1"
     json5 "^2.1.3"
-    lodash "^4.17.15"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     stylint "^2.0.0"
     stylus "^0.54.7"


### PR DESCRIPTION
When using Vetur on Vue SFC using stylus, we experienced a formatting bug caused by `stylus-supremacy` related to stylus that is colons were removed unwantedly for deep accessed properties. See https://github.com/ThisIsManta/stylus-supremacy/issues/79

The [2.15.0 release](https://github.com/ThisIsManta/stylus-supremacy/releases/tag/v2.15.0) includes the fix, so I suggest to upgrade it to make it available for the next Vetur release.

All tests passing ✓