### PR TITLE
Fix `v-model` default prop name in Vue 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Disable Vue completion in custom blocks. #2111
 - Upgrade `stylus-supremacy` to 2.15.0.
 - 🙌 Improve performance of template interpolation features. Thanks to contribution from [@jasonlyu123](https://github.com/jasonlyu123).
+- 🙌 Fix `v-model` usage in Vue 3 where default prop name is `modelValue` instead of `value. Thanks to contribution from [@yassipad](https://github.com/yassipad). #2647.
 
 ### 0.32.0 | 2021-01-21 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.32.0/vspackage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Disable Vue completion in custom blocks. #2111
 - Upgrade `stylus-supremacy` to 2.15.0.
 - 🙌 Improve performance of template interpolation features. Thanks to contribution from [@jasonlyu123](https://github.com/jasonlyu123).
-- 🙌 Fix `v-model` usage in Vue 3 where default prop name is `modelValue` instead of `value. Thanks to contribution from [@yassipad](https://github.com/yassipad). #2647.
+- 🙌 Fix `v-model` usage in Vue 3 where default prop name is `modelValue` instead of `value`. Thanks to contribution from [@yassipad](https://github.com/yassipad). #2647.
 
 ### 0.32.0 | 2021-01-21 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.32.0/vspackage)
 

--- a/server/src/modes/template/htmlMode.ts
+++ b/server/src/modes/template/htmlMode.ts
@@ -65,8 +65,9 @@ export class HTMLMode implements LanguageMode {
     }
     if (this.env.getConfig().vetur.validation.templateProps) {
       const info = this.vueInfoService ? this.vueInfoService.getInfo(document) : undefined;
+      const version = this.env.getVueVersion();
       if (info && info.componentInfo.childComponents) {
-        diagnostics.push(...doPropValidation(document, this.vueDocuments.refreshAndGet(document), info));
+        diagnostics.push(...doPropValidation(document, this.vueDocuments.refreshAndGet(document), info, version));
       }
     }
 

--- a/test/vue3/features/diagnostics/propTypeValidation.test.ts
+++ b/test/vue3/features/diagnostics/propTypeValidation.test.ts
@@ -3,7 +3,7 @@ import { testDiagnostics, testNoDiagnostics } from '../../../diagnosticHelper';
 import { sameLineRange } from '../../../util';
 import { DiagnosticSeverity } from 'vscode';
 
-describe('Should find prop type valiation errors', () => {
+describe('Should find prop type validation errors', () => {
   const rightUri = getDocUri('diagnostics/propTypeValidation/ParentRight.vue');
   const wrongUri = getDocUri('diagnostics/propTypeValidation/ParentWrong.vue');
 

--- a/test/vue3/features/diagnostics/propValidation.test.ts
+++ b/test/vue3/features/diagnostics/propValidation.test.ts
@@ -1,0 +1,12 @@
+import { getDocUri } from '../../path';
+import { testDiagnostics, testNoDiagnostics } from '../../../diagnosticHelper';
+import { sameLineRange } from '../../../util';
+import { DiagnosticSeverity } from 'vscode';
+
+describe('Should find prop validation errors', () => {
+  const rightUri = getDocUri('diagnostics/propValidation/ParentRight.vue');
+
+  it('shows no diagnostics error for prop validator in vue3 v-model', async () => {
+    await testNoDiagnostics(rightUri);
+  });
+});

--- a/test/vue3/fixture/diagnostics/propValidation/ParentRight.vue
+++ b/test/vue3/fixture/diagnostics/propValidation/ParentRight.vue
@@ -1,0 +1,29 @@
+<template>
+  <ts-child v-model="state.isZeroCount" :str="`count: ${state.count}`" :bool="state.isZeroCount" :callback="increment" :arr="['a', 'b']" />
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, reactive } from "vue";
+import TSChild from "./TSChild.vue";
+
+export default defineComponent({
+  components: {
+    TSChild
+  },
+  setup() {
+    const state: { count: number, isZeroCount: boolean } = reactive({
+      count: 0,
+      isZeroCount: computed(() => state.count === 0)
+    });
+
+    function increment() {
+      state.count++;
+    }
+
+    return {
+      state,
+      increment
+    };
+  }
+});
+</script>

--- a/test/vue3/fixture/diagnostics/propValidation/TSChild.vue
+++ b/test/vue3/fixture/diagnostics/propValidation/TSChild.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { PropType, defineComponent, ref, reactive } from "vue";
+
+export default defineComponent({
+  props: {
+    str: String,
+    bool: Boolean,
+    callback: {
+      type: Function as PropType<() => void>
+    },
+    arr: Array as PropType<string[]>,
+    camelCase: { type: Boolean, default: false },
+    modelValue: { type: Boolean, required: true }
+  }
+});
+</script>


### PR DESCRIPTION
Fix #2647.

The default prop name in Vue 3 being `modelValue` instead of `value`, a warning is currently shown when using Vue 3 and adding v-model to a component with prop `modelValue` This PR will change the default prop name based on the current Vue version.