### PR TITLE
Refactor VTI with commander.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### 0.31.0 | 2020-12-08 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.31.0/vspackage)
 
----
+----
 
 #### 🎉 RFC release 🎉
 
@@ -54,7 +54,7 @@ We have also added a new config file called `vetur.config.js`.
 See more: https://vuejs.github.io/vetur/guide/setup.html#advanced
 Reference: https://vuejs.github.io/vetur/reference/
 
----
+----
 
 - Fix pug format. #2460
 - Fix scss autocompletion. #2522
@@ -69,6 +69,7 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Improve docs.
 - Support yarn PnP support. Thanks to contribution from [@merceyz](https://github.com/merceyz). #2478.
 
+
 ### 0.30.3 | 2020-11-26 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.3/vspackage)
 
 - Fix prettier-eslint and prettier-tslint
@@ -82,24 +83,25 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Fix high CPU usage when template tag self closed. Thanks to help from [@Shinigami92](https://github.com/Shinigami92). #2468
 - Fix formatting css problem with prettier. #2467
 
+
 ### 0.30.1 | 2020-11-12 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.1/vspackage)
 
 - Fix corner case when auto import component failed. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2461.
 - Fix the `template lang='pug'` node will be cleared when formatting the vue file. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2460.
 
+
 ### 0.30.0 | 2020-11-11 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.0/vspackage)
 
----
+----
 
-#### ⚠️ Breaking change: ⚠️
-
+#### ⚠️  Breaking change: ⚠️
 The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.
 Like `prettier`, `@prettier/plugin-pug`.
 
 In this version, we try to bundle extension and reduce size. (70MB -> 9MB)
 But it's a huge change, so please open an issue if you find any problems.
 
----
+----
 
 - 🙌 Fix v-bind modifiers causing TypeScript to not find type-checked template props correctly. Thanks to contribution from [@andrewisaburden](https://github.com/andrewisaburden). #2430.
 - 🙌 Fix "File name X differs from already included file name Y only in casing" on Windows. Thanks to contribution from [@rchl](https://github.com/rchl). #2433 and #2444.
@@ -165,7 +167,7 @@ But it's a huge change, so please open an issue if you find any problems.
 
 - Add `foldingRange` support to support dynamic folding ranges such as `#region`. #899.
 - Add setting `vetur.validation.interpolation` so interpolation diagnostics and `eslint-plugin-vue` diagnostics can be configed separately. #2131.
-- Fix VLS crash for \*.vue files in node_modules. #2006.
+- Fix VLS crash for *.vue files in node_modules. #2006.
 - Upgrade to TypeScript 4.0.2 and fix symbol outline issue. #1849.
 - Improve JSDoc presentation in hover/completion in interpolation mode. #1337.
 - Improve JSDoc presentation in hover/completion/signatureHelp. #2193.
@@ -444,15 +446,15 @@ export default {
       default: 0
     }
   },
-  data() {
+  data () {
     return {
       /**
        * My msg
        */
-      msg: 'Vetur get much better completion'
-    };
+      msg: 'Vetur get much better completion',
+    }
   }
-};
+}
 </script>
 ```
 
@@ -548,7 +550,6 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
     "vetur.format.options.tabSize": 2
   }
   ```
-
 - Vetur no longer reads settings from `prettier.*`. All settings must be specified in a local configuration file. #982.
 - `prettier-eslint` is added as an option for `vetur.format.defaultFormatter.js`. #982.
 - Various bug fixes for `prettier-eslint` not reading config correctly. Thanks to contribution form [@Coder-256](https://github.com/Coder-256). #934 and #942.
@@ -648,6 +649,7 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Fix a vue-html grammar rule that does not highlight Vue templates after `</template>`. #548.
 - Upgrade grammar so broken syntax in each region will not affect syntax highlighting outside that specific region. #174.
 - Always ignore `end_with_newline` option in js-beautify so the template formats properly. #544.
+
 
 ### 0.11.3 | 2017-11-13
 
@@ -920,7 +922,6 @@ Shoutout to @HerringtonDarkholme who helped implementing many new features!
 - Improve `sass` syntax highlighting based on grammar from [robinbentley/vscode-sass-indented](https://github.com/robinbentley/vscode-sass-indented). #41.
 
 Thanks to [@sandersn](https://github.com/sandersn)'s [PR](https://github.com/octref/vetur/pull/94):
-
 - Preliminary TypeScript support (try `<script lang="ts">`)
 - Improved IntelliSense for `js/ts` in Vue SFC.
 - Correct Module Resolution (try `npm i lodash @types/lodash` and use lodash in your Vue SFC).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Disable Vue completion in custom blocks. #2111
 - Upgrade `stylus-supremacy` to 2.15.0.
 - 🙌 Improve performance of template interpolation features. Thanks to contribution from [@jasonlyu123](https://github.com/jasonlyu123).
+- Improve VTI command structure. See `vti --help`. #2722.
 
 ### 0.32.0 | 2021-01-21 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.32.0/vspackage)
 
@@ -43,7 +44,7 @@
 
 ### 0.31.0 | 2020-12-08 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.31.0/vspackage)
 
-----
+---
 
 #### 🎉 RFC release 🎉
 
@@ -53,7 +54,7 @@ We have also added a new config file called `vetur.config.js`.
 See more: https://vuejs.github.io/vetur/guide/setup.html#advanced
 Reference: https://vuejs.github.io/vetur/reference/
 
-----
+---
 
 - Fix pug format. #2460
 - Fix scss autocompletion. #2522
@@ -68,7 +69,6 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Improve docs.
 - Support yarn PnP support. Thanks to contribution from [@merceyz](https://github.com/merceyz). #2478.
 
-
 ### 0.30.3 | 2020-11-26 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.3/vspackage)
 
 - Fix prettier-eslint and prettier-tslint
@@ -82,25 +82,24 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Fix high CPU usage when template tag self closed. Thanks to help from [@Shinigami92](https://github.com/Shinigami92). #2468
 - Fix formatting css problem with prettier. #2467
 
-
 ### 0.30.1 | 2020-11-12 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.1/vspackage)
 
 - Fix corner case when auto import component failed. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2461.
 - Fix the `template lang='pug'` node will be cleared when formatting the vue file. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2460.
 
-
 ### 0.30.0 | 2020-11-11 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.0/vspackage)
 
-----
+---
 
-#### ⚠️  Breaking change: ⚠️
+#### ⚠️ Breaking change: ⚠️
+
 The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.
 Like `prettier`, `@prettier/plugin-pug`.
 
 In this version, we try to bundle extension and reduce size. (70MB -> 9MB)
 But it's a huge change, so please open an issue if you find any problems.
 
-----
+---
 
 - 🙌 Fix v-bind modifiers causing TypeScript to not find type-checked template props correctly. Thanks to contribution from [@andrewisaburden](https://github.com/andrewisaburden). #2430.
 - 🙌 Fix "File name X differs from already included file name Y only in casing" on Windows. Thanks to contribution from [@rchl](https://github.com/rchl). #2433 and #2444.
@@ -166,7 +165,7 @@ But it's a huge change, so please open an issue if you find any problems.
 
 - Add `foldingRange` support to support dynamic folding ranges such as `#region`. #899.
 - Add setting `vetur.validation.interpolation` so interpolation diagnostics and `eslint-plugin-vue` diagnostics can be configed separately. #2131.
-- Fix VLS crash for *.vue files in node_modules. #2006.
+- Fix VLS crash for \*.vue files in node_modules. #2006.
 - Upgrade to TypeScript 4.0.2 and fix symbol outline issue. #1849.
 - Improve JSDoc presentation in hover/completion in interpolation mode. #1337.
 - Improve JSDoc presentation in hover/completion/signatureHelp. #2193.
@@ -445,15 +444,15 @@ export default {
       default: 0
     }
   },
-  data () {
+  data() {
     return {
       /**
        * My msg
        */
-      msg: 'Vetur get much better completion',
-    }
+      msg: 'Vetur get much better completion'
+    };
   }
-}
+};
 </script>
 ```
 
@@ -549,6 +548,7 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
     "vetur.format.options.tabSize": 2
   }
   ```
+
 - Vetur no longer reads settings from `prettier.*`. All settings must be specified in a local configuration file. #982.
 - `prettier-eslint` is added as an option for `vetur.format.defaultFormatter.js`. #982.
 - Various bug fixes for `prettier-eslint` not reading config correctly. Thanks to contribution form [@Coder-256](https://github.com/Coder-256). #934 and #942.
@@ -648,7 +648,6 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Fix a vue-html grammar rule that does not highlight Vue templates after `</template>`. #548.
 - Upgrade grammar so broken syntax in each region will not affect syntax highlighting outside that specific region. #174.
 - Always ignore `end_with_newline` option in js-beautify so the template formats properly. #544.
-
 
 ### 0.11.3 | 2017-11-13
 
@@ -921,6 +920,7 @@ Shoutout to @HerringtonDarkholme who helped implementing many new features!
 - Improve `sass` syntax highlighting based on grammar from [robinbentley/vscode-sass-indented](https://github.com/robinbentley/vscode-sass-indented). #41.
 
 Thanks to [@sandersn](https://github.com/sandersn)'s [PR](https://github.com/octref/vetur/pull/94):
+
 - Preliminary TypeScript support (try `<script lang="ts">`)
 - Improved IntelliSense for `js/ts` in Vue SFC.
 - Correct Module Resolution (try `npm i lodash @types/lodash` and use lodash in your Vue SFC).

--- a/vti/package.json
+++ b/vti/package.json
@@ -7,6 +7,7 @@
   "author": "Pine Wu <octref@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "commander": "^7.1.0",
     "vls": "^0.7.0"
   },
   "scripts": {

--- a/vti/package.json
+++ b/vti/package.json
@@ -21,6 +21,7 @@
     "glob": "^7.1.2",
     "rollup": "^2.38.5",
     "typescript": "^4.1.5",
+    "vscode-languageclient": "^7.0.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-protocol": "^3.16.0",
     "vscode-languageserver-types": "^3.16.0",

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -1,150 +1,5 @@
-import {
-  InitializeParams,
-  InitializeRequest,
-  InitializeResult,
-  createProtocolConnection,
-  StreamMessageReader,
-  StreamMessageWriter,
-  Logger,
-  DidOpenTextDocumentNotification,
-  Diagnostic,
-  DiagnosticSeverity,
-  createConnection,
-  ServerCapabilities
-} from 'vscode-languageserver/node';
-
-import { Duplex } from 'stream';
-import { VLS } from 'vls';
-import { getInitParams } from './initParams';
-import fs from 'fs';
-import { URI } from 'vscode-uri';
-import glob from 'glob';
-import path from 'path';
-import chalk from 'chalk';
-import { codeFrameColumns, SourceLocation } from '@babel/code-frame';
-import { Range } from 'vscode-languageclient';
-
-class NullLogger implements Logger {
-  error(_message: string): void {}
-  warn(_message: string): void {}
-  info(_message: string): void {}
-  log(_message: string): void {}
-}
-
-class TestStream extends Duplex {
-  _write(chunk: string, _encoding: string, done: () => void) {
-    this.emit('data', chunk);
-    done();
-  }
-
-  _read(_size: number) {}
-}
-
-async function prepareClientConnection(workspaceUri: URI) {
-  const up = new TestStream();
-  const down = new TestStream();
-  const logger = new NullLogger();
-
-  const clientConnection = createProtocolConnection(new StreamMessageReader(down), new StreamMessageWriter(up), logger);
-
-  const serverConnection = createConnection(new StreamMessageReader(up), new StreamMessageWriter(down));
-  const vls = new VLS(serverConnection as any);
-
-  serverConnection.onInitialize(
-    async (params: InitializeParams): Promise<InitializeResult> => {
-      await vls.init(params);
-
-      console.log('Vetur initialized');
-      console.log('====================================');
-
-      return {
-        capabilities: vls.capabilities as ServerCapabilities
-      };
-    }
-  );
-
-  vls.listen();
-  clientConnection.listen();
-
-  const init = getInitParams(workspaceUri);
-
-  await clientConnection.sendRequest(InitializeRequest.type, init);
-
-  return clientConnection;
-}
-
-function range2Location(range: Range): SourceLocation {
-  return {
-    start: {
-      line: range.start.line + 1,
-      column: range.start.character + 1
-    },
-    end: {
-      line: range.end.line + 1,
-      column: range.end.character + 1
-    }
-  };
-}
-
-async function getDiagnostics(workspaceUri: URI) {
-  const clientConnection = await prepareClientConnection(workspaceUri);
-
-  const files = glob.sync('**/*.vue', { cwd: workspaceUri.fsPath, ignore: ['node_modules/**'] });
-
-  if (files.length === 0) {
-    console.log('No input files');
-    return 0;
-  }
-
-  console.log('');
-  console.log('Getting diagnostics from: ', files, '\n');
-
-  const absFilePaths = files.map(f => path.resolve(workspaceUri.fsPath, f));
-
-  let errCount = 0;
-
-  for (const absFilePath of absFilePaths) {
-    const fileText = fs.readFileSync(absFilePath, 'utf-8');
-    await clientConnection.sendNotification(DidOpenTextDocumentNotification.type, {
-      textDocument: {
-        languageId: 'vue',
-        uri: URI.file(absFilePath).toString(),
-        version: 1,
-        text: fileText
-      }
-    });
-
-    try {
-      let res = (await clientConnection.sendRequest('$/getDiagnostics', {
-        uri: URI.file(absFilePath).toString()
-      })) as Diagnostic[];
-      /**
-       * Ignore eslint errors for now
-       */
-      res = res.filter(r => r.source !== 'eslint-plugin-vue');
-      if (res.length > 0) {
-        res.forEach(d => {
-          const location = range2Location(d.range);
-          console.log(
-            `${chalk.green('File')} : ${chalk.green(absFilePath)}:${location.start.line}:${location.start.column}`
-          );
-          if (d.severity === DiagnosticSeverity.Error) {
-            console.log(`${chalk.red('Error')}: ${d.message.trim()}`);
-            errCount++;
-          } else {
-            console.log(`${chalk.yellow('Warn')} : ${d.message.trim()}`);
-          }
-          console.log(codeFrameColumns(fileText, location));
-        });
-        console.log('');
-      }
-    } catch (err) {
-      console.error(err.stack);
-    }
-  }
-
-  return errCount;
-}
+import { Command } from 'commander';
+import { diagnostics } from './commands/diagnostics';
 
 function getVersion(): string {
   const { version }: { version: string } = require('../package.json');
@@ -152,45 +7,17 @@ function getVersion(): string {
 }
 
 (async () => {
-  const myArgs = process.argv.slice(2);
+  const program = new Command();
+  program.name('vti').description('Vetur Terminal Interface').version(getVersion());
 
-  // vls diagnostics
-  if (myArgs.length > 0 && myArgs[0] === 'diagnostics') {
-    console.log('====================================');
-    console.log('Getting Vetur diagnostics');
-    let workspaceUri;
+  program
+    .command('diagnostics [workspace]')
+    .description('Print all diagnostics')
+    .action(workspace => {
+      diagnostics(workspace);
+    });
 
-    if (myArgs[1]) {
-      const absPath = path.resolve(process.cwd(), myArgs[1]);
-      console.log(`Loading Vetur in workspace path: ${chalk.green(absPath)}`);
-      workspaceUri = URI.file(absPath);
-    } else {
-      console.log(`Loading Vetur in current directory: ${chalk.green(process.cwd())}`);
-      workspaceUri = URI.file(process.cwd());
-    }
-
-    const errCount = await getDiagnostics(workspaceUri);
-    console.log('====================================');
-
-    if (errCount === 0) {
-      console.log(chalk.green(`VTI found no error`));
-      process.exit(0);
-    } else {
-      console.log(chalk.red(`VTI found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`));
-      process.exit(1);
-    }
-  } else if (myArgs.length > 0 && myArgs[0] === 'version') {
-    console.log(getVersion());
-  } else {
-    // no args or wrong first args
-    console.log('Vetur Terminal Interface');
-    console.log('');
-    console.log('Usage:');
-    console.log('');
-    console.log('  vti diagnostics ---- Print all diagnostics');
-    console.log('  vti version     ---- Show VTI version');
-    console.log('');
-  }
+  program.parse(process.argv);
 })().catch(err => {
   console.error(`VTI operation failed with error`);
   console.error(err.stack);

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -13,8 +13,8 @@ function getVersion(): string {
   program
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
-    .action(workspace => {
-      diagnostics(workspace);
+    .action(async workspace => {
+      await diagnostics(workspace);
     });
 
   program.parse(process.argv);

--- a/vti/src/commands/diagnostics.ts
+++ b/vti/src/commands/diagnostics.ts
@@ -1,0 +1,173 @@
+import {
+  InitializeParams,
+  InitializeRequest,
+  InitializeResult,
+  createProtocolConnection,
+  StreamMessageReader,
+  StreamMessageWriter,
+  Logger,
+  DidOpenTextDocumentNotification,
+  Diagnostic,
+  DiagnosticSeverity,
+  createConnection,
+  ServerCapabilities
+} from 'vscode-languageserver/node';
+
+import { Duplex } from 'stream';
+import { VLS } from 'vls';
+import { getInitParams } from '../initParams';
+import fs from 'fs';
+import { URI } from 'vscode-uri';
+import glob from 'glob';
+import path from 'path';
+import chalk from 'chalk';
+import { codeFrameColumns, SourceLocation } from '@babel/code-frame';
+import { Range } from 'vscode-languageclient';
+
+export async function diagnostics(workspace: string | null) {
+  console.log('====================================');
+  console.log('Getting Vetur diagnostics');
+  let workspaceUri;
+
+  if (workspace) {
+    const absPath = path.resolve(process.cwd(), workspace);
+    console.log(`Loading Vetur in workspace path: ${chalk.green(absPath)}`);
+    workspaceUri = URI.file(absPath);
+  } else {
+    console.log(`Loading Vetur in current directory: ${chalk.green(process.cwd())}`);
+    workspaceUri = URI.file(process.cwd());
+  }
+
+  const errCount = await getDiagnostics(workspaceUri);
+  console.log('====================================');
+
+  if (errCount === 0) {
+    console.log(chalk.green(`VTI found no error`));
+    process.exit(0);
+  } else {
+    console.log(chalk.red(`VTI found ${errCount} ${errCount === 1 ? 'error' : 'errors'}`));
+    process.exit(1);
+  }
+}
+
+class NullLogger implements Logger {
+  error(_message: string): void {}
+  warn(_message: string): void {}
+  info(_message: string): void {}
+  log(_message: string): void {}
+}
+
+class TestStream extends Duplex {
+  _write(chunk: string, _encoding: string, done: () => void) {
+    this.emit('data', chunk);
+    done();
+  }
+
+  _read(_size: number) {}
+}
+
+async function prepareClientConnection(workspaceUri: URI) {
+  const up = new TestStream();
+  const down = new TestStream();
+  const logger = new NullLogger();
+
+  const clientConnection = createProtocolConnection(new StreamMessageReader(down), new StreamMessageWriter(up), logger);
+
+  const serverConnection = createConnection(new StreamMessageReader(up), new StreamMessageWriter(down));
+  const vls = new VLS(serverConnection as any);
+
+  serverConnection.onInitialize(
+    async (params: InitializeParams): Promise<InitializeResult> => {
+      await vls.init(params);
+
+      console.log('Vetur initialized');
+      console.log('====================================');
+
+      return {
+        capabilities: vls.capabilities as ServerCapabilities
+      };
+    }
+  );
+
+  vls.listen();
+  clientConnection.listen();
+
+  const init = getInitParams(workspaceUri);
+
+  await clientConnection.sendRequest(InitializeRequest.type, init);
+
+  return clientConnection;
+}
+
+function range2Location(range: Range): SourceLocation {
+  return {
+    start: {
+      line: range.start.line + 1,
+      column: range.start.character + 1
+    },
+    end: {
+      line: range.end.line + 1,
+      column: range.end.character + 1
+    }
+  };
+}
+
+async function getDiagnostics(workspaceUri: URI) {
+  const clientConnection = await prepareClientConnection(workspaceUri);
+
+  const files = glob.sync('**/*.vue', { cwd: workspaceUri.fsPath, ignore: ['node_modules/**'] });
+
+  if (files.length === 0) {
+    console.log('No input files');
+    return 0;
+  }
+
+  console.log('');
+  console.log('Getting diagnostics from: ', files, '\n');
+
+  const absFilePaths = files.map(f => path.resolve(workspaceUri.fsPath, f));
+
+  let errCount = 0;
+
+  for (const absFilePath of absFilePaths) {
+    const fileText = fs.readFileSync(absFilePath, 'utf-8');
+    await clientConnection.sendNotification(DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        languageId: 'vue',
+        uri: URI.file(absFilePath).toString(),
+        version: 1,
+        text: fileText
+      }
+    });
+
+    try {
+      let res = (await clientConnection.sendRequest('$/getDiagnostics', {
+        uri: URI.file(absFilePath).toString()
+      })) as Diagnostic[];
+      /**
+       * Ignore eslint errors for now
+       */
+      res = res.filter(r => r.source !== 'eslint-plugin-vue');
+      if (res.length > 0) {
+        res.forEach(d => {
+          const location = range2Location(d.range);
+          console.log(
+            `${chalk.green('File')} : ${chalk.green(absFilePath)}:${location.start.line}:${location.start.column}`
+          );
+          if (d.severity === DiagnosticSeverity.Error) {
+            console.log(`${chalk.red('Error')}: ${d.message.trim()}`);
+            errCount++;
+          } else {
+            console.log(`${chalk.yellow('Warn')} : ${d.message.trim()}`);
+          }
+          console.log(codeFrameColumns(fileText, location));
+        });
+        console.log('');
+      }
+    } catch (err) {
+      console.error(err.stack);
+    }
+  }
+
+  return errCount;
+}

--- a/vti/tsconfig.json
+++ b/vti/tsconfig.json
@@ -5,7 +5,5 @@
     "outDir": "./dist",
     "rootDir": "src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src/**/*"]
 }

--- a/vti/yarn.lock
+++ b/vti/yarn.lock
@@ -590,6 +590,13 @@ lodash@^4.17.15, lodash@^4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -726,6 +733,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -879,6 +893,15 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
+vscode-languageclient@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
+  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+  dependencies:
+    minimatch "^3.0.4"
+    semver "^7.3.4"
+    vscode-languageserver-protocol "3.16.0"
+
 vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
@@ -932,3 +955,8 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==

--- a/vti/yarn.lock
+++ b/vti/yarn.lock
@@ -197,6 +197,11 @@ commander@^2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Resolves #2451.

Refactoring VTI with [commander.js](https://github.com/tj/commander.js).

```bash
$ vti --help
Usage: vti [options] [command]

Vetur Terminal Interface

Options:
  -V, --version            output the version number
  -h, --help               display help for command

Commands:
  diagnostics [workspace]  Print all diagnostics
  help [command]           display help for command
```

- To follow general CLI design, I replaced `vti version` with `vti --version`. Maybe `vti version` should be remained if we need compatibility.

- We also should refactor `diagnostics.ts` but not in the scope for now.