### PR TITLE
Improve Vue version detection

### DIFF
--- a/server/src/utils/vueVersion.ts
+++ b/server/src/utils/vueVersion.ts
@@ -31,7 +31,7 @@ export function inferVueVersion(packagePath: string | undefined): VueVersion {
 
     if (vueDependencyVersion) {
       // use a sloppy method to infer version, to reduce dep on semver or so
-      const vueDep = vueDependencyVersion.match(/\d+\.\d+/)[0];
+      const vueDep = vueDependencyVersion.match(/\d+(\.\d+)?/)[0];
       const sloppyVersion = parseFloat(vueDep);
       return floatVersionToEnum(sloppyVersion);
     }


### PR DESCRIPTION
I installed Vue with `yarn add vue@3` and Yarn added `"vue": "3"` to `package.json` and then I configured Vetur to lint my code. For some reason I was getting `vue/no-multiple-template-root` error in a Vue 3 project, I removed Vue and then reinstalled it, but with a specific version and the error was gone. I changed the regexp inside `inferVueVersion` to handle such cases where only major version is saved in `package.json`.