### PR TITLE
add --log-level option to vti diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+### Not Released Yet
+
+- Add `--error-only` option for `vti diagnostics` to ignore warnings #2752.
+
 ### 0.33.1 | 2021-03-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.1/vspackage)
 
 - Added new ts and js snippets for the Composition API. Thanks to contribution from [@Namchee](https://github.com/Namchee). #2741
 - Fix prefix dot folder or file name with eslint, and effect other diagnostics. #2717
-
 ### 0.33.0 | 2021-03-02 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.0/vspackage)
 
 - Disable Vue completion in custom blocks. #2111

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Not Released Yet
 
-- Add `--error-only` option for `vti diagnostics` to ignore warnings #2752.
+- Add `--log-level` option for `vti diagnostics` to configure log level to print. #2752.
 
 ### 0.33.1 | 2021-03-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.1/vspackage)
 
@@ -58,7 +58,7 @@
 
 ### 0.31.0 | 2020-12-08 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.31.0/vspackage)
 
-----
+---
 
 #### 🎉 RFC release 🎉
 
@@ -68,7 +68,7 @@ We have also added a new config file called `vetur.config.js`.
 See more: https://vuejs.github.io/vetur/guide/setup.html#advanced
 Reference: https://vuejs.github.io/vetur/reference/
 
-----
+---
 
 - Fix pug format. #2460
 - Fix scss autocompletion. #2522
@@ -83,7 +83,6 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Improve docs.
 - Support yarn PnP support. Thanks to contribution from [@merceyz](https://github.com/merceyz). #2478.
 
-
 ### 0.30.3 | 2020-11-26 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.3/vspackage)
 
 - Fix prettier-eslint and prettier-tslint
@@ -97,25 +96,24 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Fix high CPU usage when template tag self closed. Thanks to help from [@Shinigami92](https://github.com/Shinigami92). #2468
 - Fix formatting css problem with prettier. #2467
 
-
 ### 0.30.1 | 2020-11-12 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.1/vspackage)
 
 - Fix corner case when auto import component failed. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2461.
 - Fix the `template lang='pug'` node will be cleared when formatting the vue file. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2460.
 
-
 ### 0.30.0 | 2020-11-11 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.0/vspackage)
 
-----
+---
 
-#### ⚠️  Breaking change: ⚠️
+#### ⚠️ Breaking change: ⚠️
+
 The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.
 Like `prettier`, `@prettier/plugin-pug`.
 
 In this version, we try to bundle extension and reduce size. (70MB -> 9MB)
 But it's a huge change, so please open an issue if you find any problems.
 
-----
+---
 
 - 🙌 Fix v-bind modifiers causing TypeScript to not find type-checked template props correctly. Thanks to contribution from [@andrewisaburden](https://github.com/andrewisaburden). #2430.
 - 🙌 Fix "File name X differs from already included file name Y only in casing" on Windows. Thanks to contribution from [@rchl](https://github.com/rchl). #2433 and #2444.
@@ -181,7 +179,7 @@ But it's a huge change, so please open an issue if you find any problems.
 
 - Add `foldingRange` support to support dynamic folding ranges such as `#region`. #899.
 - Add setting `vetur.validation.interpolation` so interpolation diagnostics and `eslint-plugin-vue` diagnostics can be configed separately. #2131.
-- Fix VLS crash for *.vue files in node_modules. #2006.
+- Fix VLS crash for \*.vue files in node_modules. #2006.
 - Upgrade to TypeScript 4.0.2 and fix symbol outline issue. #1849.
 - Improve JSDoc presentation in hover/completion in interpolation mode. #1337.
 - Improve JSDoc presentation in hover/completion/signatureHelp. #2193.
@@ -460,15 +458,15 @@ export default {
       default: 0
     }
   },
-  data () {
+  data() {
     return {
       /**
        * My msg
        */
-      msg: 'Vetur get much better completion',
-    }
+      msg: 'Vetur get much better completion'
+    };
   }
-}
+};
 </script>
 ```
 
@@ -564,6 +562,7 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
     "vetur.format.options.tabSize": 2
   }
   ```
+
 - Vetur no longer reads settings from `prettier.*`. All settings must be specified in a local configuration file. #982.
 - `prettier-eslint` is added as an option for `vetur.format.defaultFormatter.js`. #982.
 - Various bug fixes for `prettier-eslint` not reading config correctly. Thanks to contribution form [@Coder-256](https://github.com/Coder-256). #934 and #942.
@@ -663,7 +662,6 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Fix a vue-html grammar rule that does not highlight Vue templates after `</template>`. #548.
 - Upgrade grammar so broken syntax in each region will not affect syntax highlighting outside that specific region. #174.
 - Always ignore `end_with_newline` option in js-beautify so the template formats properly. #544.
-
 
 ### 0.11.3 | 2017-11-13 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.11.3/vspackage)
 
@@ -936,6 +934,7 @@ Shoutout to @HerringtonDarkholme who helped implementing many new features!
 - Improve `sass` syntax highlighting based on grammar from [robinbentley/vscode-sass-indented](https://github.com/robinbentley/vscode-sass-indented). #41.
 
 Thanks to [@sandersn](https://github.com/sandersn)'s [PR](https://github.com/octref/vetur/pull/94):
+
 - Preliminary TypeScript support (try `<script lang="ts">`)
 - Improved IntelliSense for `js/ts` in Vue SFC.
 - Correct Module Resolution (try `npm i lodash @types/lodash` and use lodash in your Vue SFC).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added new ts and js snippets for the Composition API. Thanks to contribution from [@Namchee](https://github.com/Namchee). #2741
 - Fix prefix dot folder or file name with eslint, and effect other diagnostics. #2717
+
 ### 0.33.0 | 2021-03-02 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.0/vspackage)
 
 - Disable Vue completion in custom blocks. #2111
@@ -58,7 +59,7 @@
 
 ### 0.31.0 | 2020-12-08 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.31.0/vspackage)
 
----
+----
 
 #### 🎉 RFC release 🎉
 
@@ -68,7 +69,7 @@ We have also added a new config file called `vetur.config.js`.
 See more: https://vuejs.github.io/vetur/guide/setup.html#advanced
 Reference: https://vuejs.github.io/vetur/reference/
 
----
+----
 
 - Fix pug format. #2460
 - Fix scss autocompletion. #2522
@@ -83,6 +84,7 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Improve docs.
 - Support yarn PnP support. Thanks to contribution from [@merceyz](https://github.com/merceyz). #2478.
 
+
 ### 0.30.3 | 2020-11-26 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.3/vspackage)
 
 - Fix prettier-eslint and prettier-tslint
@@ -96,24 +98,25 @@ Reference: https://vuejs.github.io/vetur/reference/
 - Fix high CPU usage when template tag self closed. Thanks to help from [@Shinigami92](https://github.com/Shinigami92). #2468
 - Fix formatting css problem with prettier. #2467
 
+
 ### 0.30.1 | 2020-11-12 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.1/vspackage)
 
 - Fix corner case when auto import component failed. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2461.
 - Fix the `template lang='pug'` node will be cleared when formatting the vue file. Thanks to contribution from [@yoyo930021](https://github.com/yoyo930021). #2460.
 
+
 ### 0.30.0 | 2020-11-11 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.30.0/vspackage)
 
----
+----
 
-#### ⚠️ Breaking change: ⚠️
-
+#### ⚠️  Breaking change: ⚠️
 The `vetur.useWorkspaceDependencies` option affect all runtime dependencies now.
 Like `prettier`, `@prettier/plugin-pug`.
 
 In this version, we try to bundle extension and reduce size. (70MB -> 9MB)
 But it's a huge change, so please open an issue if you find any problems.
 
----
+----
 
 - 🙌 Fix v-bind modifiers causing TypeScript to not find type-checked template props correctly. Thanks to contribution from [@andrewisaburden](https://github.com/andrewisaburden). #2430.
 - 🙌 Fix "File name X differs from already included file name Y only in casing" on Windows. Thanks to contribution from [@rchl](https://github.com/rchl). #2433 and #2444.
@@ -179,7 +182,7 @@ But it's a huge change, so please open an issue if you find any problems.
 
 - Add `foldingRange` support to support dynamic folding ranges such as `#region`. #899.
 - Add setting `vetur.validation.interpolation` so interpolation diagnostics and `eslint-plugin-vue` diagnostics can be configed separately. #2131.
-- Fix VLS crash for \*.vue files in node_modules. #2006.
+- Fix VLS crash for *.vue files in node_modules. #2006.
 - Upgrade to TypeScript 4.0.2 and fix symbol outline issue. #1849.
 - Improve JSDoc presentation in hover/completion in interpolation mode. #1337.
 - Improve JSDoc presentation in hover/completion/signatureHelp. #2193.
@@ -458,15 +461,15 @@ export default {
       default: 0
     }
   },
-  data() {
+  data () {
     return {
       /**
        * My msg
        */
-      msg: 'Vetur get much better completion'
-    };
+      msg: 'Vetur get much better completion',
+    }
   }
-};
+}
 </script>
 ```
 
@@ -562,7 +565,6 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
     "vetur.format.options.tabSize": 2
   }
   ```
-
 - Vetur no longer reads settings from `prettier.*`. All settings must be specified in a local configuration file. #982.
 - `prettier-eslint` is added as an option for `vetur.format.defaultFormatter.js`. #982.
 - Various bug fixes for `prettier-eslint` not reading config correctly. Thanks to contribution form [@Coder-256](https://github.com/Coder-256). #934 and #942.
@@ -662,6 +664,7 @@ Read updated doc at: https://vuejs.github.io/vetur/formatting.html#formatters.
 - Fix a vue-html grammar rule that does not highlight Vue templates after `</template>`. #548.
 - Upgrade grammar so broken syntax in each region will not affect syntax highlighting outside that specific region. #174.
 - Always ignore `end_with_newline` option in js-beautify so the template formats properly. #544.
+
 
 ### 0.11.3 | 2017-11-13 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.11.3/vspackage)
 
@@ -934,7 +937,6 @@ Shoutout to @HerringtonDarkholme who helped implementing many new features!
 - Improve `sass` syntax highlighting based on grammar from [robinbentley/vscode-sass-indented](https://github.com/robinbentley/vscode-sass-indented). #41.
 
 Thanks to [@sandersn](https://github.com/sandersn)'s [PR](https://github.com/octref/vetur/pull/94):
-
 - Preliminary TypeScript support (try `<script lang="ts">`)
 - Improved IntelliSense for `js/ts` in Vue SFC.
 - Correct Module Resolution (try `npm i lodash @types/lodash` and use lodash in your Vue SFC).

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -13,8 +13,10 @@ function getVersion(): string {
   program
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
-    .action(async workspace => {
-      await diagnostics(workspace);
+    .option('-e, --error-only', 'Print only errors', false)
+    .action(async (workspace, options) => {
+      console.log(options);
+      await diagnostics(workspace, options.errorOnly);
     });
 
   program.parse(process.argv);

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -15,7 +15,6 @@ function getVersion(): string {
     .description('Print all diagnostics')
     .option('-e, --error-only', 'Print only errors', false)
     .action(async (workspace, options) => {
-      console.log(options);
       await diagnostics(workspace, options.errorOnly);
     });
 

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -13,9 +13,18 @@ function getVersion(): string {
   program
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
-    .option('-e, --error-only', 'Print only errors', false)
+    .option('-l, --log-level <logLevel>', 'Log level to print', 'WARN')
     .action(async (workspace, options) => {
-      await diagnostics(workspace, options.errorOnly);
+      const logLevelOption: unknown = options.logLevel;
+      if (
+        logLevelOption !== 'ERROR' &&
+        logLevelOption !== 'WARN' &&
+        logLevelOption !== 'INFO' &&
+        logLevelOption !== 'HINT'
+      ) {
+        throw new Error(`Invalid log level: ${logLevelOption}`);
+      }
+      await diagnostics(workspace, logLevelOption);
     });
 
   program.parse(process.argv);

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -1,9 +1,13 @@
 import { Command, Option } from 'commander';
-import { diagnostics, logLevels } from './commands/diagnostics';
+import { diagnostics, LogLevel, logLevels } from './commands/diagnostics';
 
 function getVersion(): string {
   const { version }: { version: string } = require('../package.json');
   return `v${version}`;
+}
+
+function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
+  return typeof logLevelInput === 'string' && (logLevels as ReadonlyArray<string>).includes(logLevelInput);
 }
 
 (async () => {
@@ -21,12 +25,7 @@ function getVersion(): string {
     )
     .action(async (workspace, options) => {
       const logLevelOption: unknown = options.logLevel;
-      if (
-        logLevelOption !== 'ERROR' &&
-        logLevelOption !== 'WARN' &&
-        logLevelOption !== 'INFO' &&
-        logLevelOption !== 'HINT'
-      ) {
+      if (!validateLogLevel(logLevelOption)) {
         throw new Error(`Invalid log level: ${logLevelOption}`);
       }
       await diagnostics(workspace, logLevelOption);

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -1,5 +1,5 @@
-import { Command } from 'commander';
-import { diagnostics } from './commands/diagnostics';
+import { Command, Option } from 'commander';
+import { diagnostics, logLevels } from './commands/diagnostics';
 
 function getVersion(): string {
   const { version }: { version: string } = require('../package.json');
@@ -13,7 +13,12 @@ function getVersion(): string {
   program
     .command('diagnostics [workspace]')
     .description('Print all diagnostics')
-    .option('-l, --log-level <logLevel>', 'Log level to print', 'WARN')
+    .addOption(
+      new Option('-l, --log-level <logLevel>', 'Log level to print')
+        .default('WARN')
+        // logLevels is readonly array but .choices need read-write array (because of weak typing)
+        .choices((logLevels as unknown) as string[])
+    )
     .action(async (workspace, options) => {
       const logLevelOption: unknown = options.logLevel;
       if (

--- a/vti/src/commands/diagnostics.ts
+++ b/vti/src/commands/diagnostics.ts
@@ -24,7 +24,7 @@ import chalk from 'chalk';
 import { codeFrameColumns, SourceLocation } from '@babel/code-frame';
 import { Range } from 'vscode-languageclient';
 
-export async function diagnostics(workspace: string | null) {
+export async function diagnostics(workspace: string | null, onlyError: boolean) {
   console.log('====================================');
   console.log('Getting Vetur diagnostics');
   let workspaceUri;
@@ -38,7 +38,7 @@ export async function diagnostics(workspace: string | null) {
     workspaceUri = URI.file(process.cwd());
   }
 
-  const errCount = await getDiagnostics(workspaceUri);
+  const errCount = await getDiagnostics(workspaceUri, onlyError);
   console.log('====================================');
 
   if (errCount === 0) {
@@ -112,7 +112,7 @@ function range2Location(range: Range): SourceLocation {
   };
 }
 
-async function getDiagnostics(workspaceUri: URI) {
+async function getDiagnostics(workspaceUri: URI, onlyError: boolean) {
   const clientConnection = await prepareClientConnection(workspaceUri);
 
   const files = glob.sync('**/*.vue', { cwd: workspaceUri.fsPath, ignore: ['node_modules/**'] });
@@ -148,6 +148,9 @@ async function getDiagnostics(workspaceUri: URI) {
        * Ignore eslint errors for now
        */
       res = res.filter(r => r.source !== 'eslint-plugin-vue');
+      if (onlyError) {
+        res = res.filter(r => r.severity === DiagnosticSeverity.Error);
+      }
       if (res.length > 0) {
         res.forEach(d => {
           const location = range2Location(d.range);

--- a/vti/src/commands/diagnostics.ts
+++ b/vti/src/commands/diagnostics.ts
@@ -24,7 +24,8 @@ import chalk from 'chalk';
 import { codeFrameColumns, SourceLocation } from '@babel/code-frame';
 import { Range } from 'vscode-languageclient';
 
-export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'HINT';
+export type LogLevel = typeof logLevels[number];
+export const logLevels = ['ERROR', 'WARN', 'INFO', 'HINT'] as const;
 
 export async function diagnostics(workspace: string | null, logLevel: LogLevel) {
   console.log('====================================');

--- a/vti/src/commands/diagnostics.ts
+++ b/vti/src/commands/diagnostics.ts
@@ -26,6 +26,12 @@ import { Range } from 'vscode-languageclient';
 
 export type LogLevel = typeof logLevels[number];
 export const logLevels = ['ERROR', 'WARN', 'INFO', 'HINT'] as const;
+const logLevel2Severity = {
+  ERROR: DiagnosticSeverity.Error,
+  WARN: DiagnosticSeverity.Warning,
+  INFO: DiagnosticSeverity.Information,
+  HINT: DiagnosticSeverity.Hint
+};
 
 export async function diagnostics(workspace: string | null, logLevel: LogLevel) {
   console.log('====================================');
@@ -41,7 +47,7 @@ export async function diagnostics(workspace: string | null, logLevel: LogLevel) 
     workspaceUri = URI.file(process.cwd());
   }
 
-  const errCount = await getDiagnostics(workspaceUri, logLevel2Severity(logLevel));
+  const errCount = await getDiagnostics(workspaceUri, logLevel2Severity[logLevel]);
   console.log('====================================');
 
   if (errCount === 0) {
@@ -113,19 +119,6 @@ function range2Location(range: Range): SourceLocation {
       column: range.end.character + 1
     }
   };
-}
-
-function logLevel2Severity(logLevel: LogLevel): DiagnosticSeverity {
-  switch (logLevel) {
-    case 'ERROR':
-      return DiagnosticSeverity.Error;
-    case 'WARN':
-      return DiagnosticSeverity.Warning;
-    case 'INFO':
-      return DiagnosticSeverity.Information;
-    case 'HINT':
-      return DiagnosticSeverity.Hint;
-  }
 }
 
 async function getDiagnostics(workspaceUri: URI, severity: DiagnosticSeverity) {


### PR DESCRIPTION
<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->

Resolves #2723.

`vti diagnostics --log-level ERROR` to ignore warns and print only errors.

```bash
$ vti diagnostics --help
Usage: vti diagnostics [options] [workspace]

Print all diagnostics

Options:
  -l, --log-level <logLevel>  Log level to print (choices: "ERROR", "WARN", "INFO", "HINT", default: "WARN")
  -h, --help                  display help for command
```