### PR TITLE
new composition api script snippets for ts and js

### DIFF
--- a/server/src/modes/vue/veturSnippets/script/composition-js.vue
+++ b/server/src/modes/vue/veturSnippets/script/composition-js.vue
@@ -1,0 +1,7 @@
+<script>
+export default {
+\tsetup() {
+\t\t${0}
+\t},
+}
+</script>

--- a/server/src/modes/vue/veturSnippets/script/composition-ts.vue
+++ b/server/src/modes/vue/veturSnippets/script/composition-ts.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
 \tsetup() {

--- a/server/src/modes/vue/veturSnippets/script/composition-ts.vue
+++ b/server/src/modes/vue/veturSnippets/script/composition-ts.vue
@@ -1,0 +1,9 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+\tsetup() {
+\t\t${0}
+\t},
+})
+</script>


### PR DESCRIPTION
This adds the feature request, requested by [@Namchee](https://github.com/Namchee) in issue #2741 


I would like to point out that I didn't add an entry to the changelog since there was no section for the upcoming release as it stated in [Pull Request Guidance](https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance) 
> "In CHANGELOG.md, at the end of the section for the upcoming release, add a new line that describes your changes."

But this is what I would have added:
```
- Added new ts and js snippets for the Composition API. Thanks to contribution from [@Namchee](https://github.com/Namchee). #2741
````

Also, I chose not to use the import statement [@Namchee](https://github.com/Namchee) suggested

```js
import { defineComponent } from '@vue/composition-api';
```
but instead opted for: 
```js
import { defineComponent } from 'vue';
```
since that is the way it is expressed in the official vue documentation.

![image](https://user-images.githubusercontent.com/43272438/110114401-e1c06600-7db4-11eb-8576-bd5dea19edc4.png)

