### PR TITLE
Semantic tokens for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -516,6 +516,11 @@
           "default": true,
           "description": "Whether to automatic updating import path when rename or move a file"
         },
+        "vetur.languageFeatures.semanticTokens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to enable semantic highlighting. Currently only works for typescript"
+        },
         "vetur.trace.server": {
           "type": "string",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -560,7 +560,14 @@
           "description": "Enable template interpolation service that offers hover / definition / references in Vue interpolations."
         }
       }
-    }
+    },
+    "semanticTokenScopes": [
+      {
+        "scopes": {
+          "property.refValue": ["entity.name.function"]
+        }
+      }
+    ]
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -65,6 +65,7 @@ export interface VLSConfig {
     languageFeatures: {
       codeActions: boolean;
       updateImportOnFileMove: boolean;
+      semanticTokens: boolean;
     };
     trace: {
       server: 'off' | 'messages' | 'verbose';
@@ -128,7 +129,8 @@ export function getDefaultVLSConfig(): VLSFullConfig {
       },
       languageFeatures: {
         codeActions: true,
-        updateImportOnFileMove: true
+        updateImportOnFileMove: true,
+        semanticTokens: true
       },
       trace: {
         server: 'off'

--- a/server/src/embeddedSupport/languageModes.ts
+++ b/server/src/embeddedSupport/languageModes.ts
@@ -74,7 +74,7 @@ export interface LanguageMode {
   getColorPresentations?(document: TextDocument, color: Color, range: Range): ColorPresentation[];
   getFoldingRanges?(document: TextDocument): FoldingRange[];
   getRenameFileEdit?(renames: FileRename): TextDocumentEdit[];
-  getSemanticTokens?(document: TextDocument, range?: Range): SemanticTokenData[] | null;
+  getSemanticTokens?(document: TextDocument, range?: Range): SemanticTokenData[];
 
   onDocumentChanged?(filePath: string): void;
   onDocumentRemoved(document: TextDocument): void;

--- a/server/src/embeddedSupport/languageModes.ts
+++ b/server/src/embeddedSupport/languageModes.ts
@@ -31,7 +31,7 @@ import { getCSSMode, getSCSSMode, getLESSMode, getPostCSSMode } from '../modes/s
 import { getJavascriptMode } from '../modes/script/javascript';
 import { VueHTMLMode } from '../modes/template';
 import { getStylusMode } from '../modes/style/stylus';
-import { DocumentContext } from '../types';
+import { DocumentContext, SemanticTokenData } from '../types';
 import { VueInfoService } from '../services/vueInfoService';
 import { DependencyService } from '../services/dependencyService';
 import { nullMode } from '../modes/nullMode';
@@ -74,6 +74,7 @@ export interface LanguageMode {
   getColorPresentations?(document: TextDocument, color: Color, range: Range): ColorPresentation[];
   getFoldingRanges?(document: TextDocument): FoldingRange[];
   getRenameFileEdit?(renames: FileRename): TextDocumentEdit[];
+  getSemanticTokens?(document: TextDocument, range?: Range): SemanticTokenData[] | null;
 
   onDocumentChanged?(filePath: string): void;
   onDocumentRemoved(document: TextDocument): void;

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -804,7 +804,7 @@ export async function getJavascriptMode(
     getSemanticTokens(doc: TextDocument, range?: Range) {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
       const scriptText = scriptDoc.getText();
-      if (scriptText.trim().length > SEMANTIC_TOKEN_CONTENT_LENGTH_LIMIT) {
+      if (!range && scriptText.trim().length > SEMANTIC_TOKEN_CONTENT_LENGTH_LIMIT) {
         return null;
       }
 

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -804,8 +804,8 @@ export async function getJavascriptMode(
     getSemanticTokens(doc: TextDocument, range?: Range) {
       const { scriptDoc, service } = updateCurrentVueTextDocument(doc);
       const scriptText = scriptDoc.getText();
-      if (!range && scriptText.trim().length > SEMANTIC_TOKEN_CONTENT_LENGTH_LIMIT) {
-        return null;
+      if (scriptText.trim().length > SEMANTIC_TOKEN_CONTENT_LENGTH_LIMIT) {
+        return [];
       }
 
       const fileFsPath = getFileFsPath(doc.uri);

--- a/server/src/modes/script/semanticToken.ts
+++ b/server/src/modes/script/semanticToken.ts
@@ -1,4 +1,7 @@
+import ts from 'typescript';
 import { SemanticTokensLegend, SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver';
+import { RuntimeLibrary } from '../../services/dependencyService';
+import { SemanticTokenOffsetData } from '../../types';
 
 /* tslint:disable:max-line-length */
 /**
@@ -31,7 +34,10 @@ export const enum TokenModifier {
   async,
   readonly,
   defaultLibrary,
-  local
+  local,
+
+  // vue composition api
+  refValue
 }
 
 export function getSemanticTokenLegends(): SemanticTokensLegend {
@@ -43,7 +49,10 @@ export function getSemanticTokenLegends(): SemanticTokensLegend {
     [TokenModifier.async, SemanticTokenModifiers.async],
     [TokenModifier.readonly, SemanticTokenModifiers.readonly],
     [TokenModifier.defaultLibrary, SemanticTokenModifiers.defaultLibrary],
-    [TokenModifier.local, 'local']
+    [TokenModifier.local, 'local'],
+
+    // vue
+    [TokenModifier.refValue, 'refValue']
   ] as const).forEach(([tsModifier, legend]) => (tokenModifiers[tsModifier] = legend));
 
   const tokenTypes: string[] = [];

--- a/server/src/modes/script/semanticToken.ts
+++ b/server/src/modes/script/semanticToken.ts
@@ -108,20 +108,12 @@ export function addCompositionApiRefTokens(
   const typeChecker = program.getTypeChecker();
 
   walk(sourceFile, node => {
-    const possiblyRefValue =
-      ts.isIdentifier(node) && node.text === 'value' && ts.isPropertyAccessExpression(node.parent);
-    if (!possiblyRefValue) {
+    if (!ts.isIdentifier(node) || node.text !== 'value' || !ts.isPropertyAccessExpression(node.parent)) {
       return;
     }
     const propertyAccess = node.parent;
-    if (!ts.isPropertyAccessExpression(propertyAccess)) {
-      return;
-    }
 
     let parentSymbol = typeChecker.getTypeAtLocation(propertyAccess.expression).symbol;
-    if (!parentSymbol) {
-      return;
-    }
 
     if (parentSymbol.flags & tsModule.SymbolFlags.Alias) {
       parentSymbol = typeChecker.getAliasedSymbol(parentSymbol);

--- a/server/src/modes/script/semanticTokenLegend.ts
+++ b/server/src/modes/script/semanticTokenLegend.ts
@@ -1,0 +1,72 @@
+import { SemanticTokensLegend, SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver';
+
+/* tslint:disable:max-line-length */
+/**
+ * extended from https://github.com/microsoft/TypeScript/blob/35c8df04ad959224fad9037e340c1e50f0540a49/src/services/classifier2020.ts#L9
+ * so that we don't have to map it into our own legend
+ */
+export const enum TokenType {
+  class,
+  enum,
+  interface,
+  namespace,
+  typeParameter,
+  type,
+  parameter,
+  variable,
+  enumMember,
+  property,
+  function,
+  member
+}
+
+/* tslint:disable:max-line-length */
+/**
+ * adopted from https://github.com/microsoft/TypeScript/blob/35c8df04ad959224fad9037e340c1e50f0540a49/src/services/classifier2020.ts#L13
+ * so that we don't have to map it into our own legend
+ */
+export const enum TokenModifier {
+  declaration,
+  static,
+  async,
+  readonly,
+  defaultLibrary,
+  local
+}
+
+export function getSemanticTokenLegends(): SemanticTokensLegend {
+  const tokenModifiers: string[] = [];
+
+  ([
+    [TokenModifier.declaration, SemanticTokenModifiers.declaration],
+    [TokenModifier.static, SemanticTokenModifiers.static],
+    [TokenModifier.async, SemanticTokenModifiers.async],
+    [TokenModifier.readonly, SemanticTokenModifiers.readonly],
+    [TokenModifier.defaultLibrary, SemanticTokenModifiers.defaultLibrary],
+    [TokenModifier.local, 'local']
+  ] as const).forEach(([tsModifier, legend]) => (tokenModifiers[tsModifier] = legend));
+
+  const tokenTypes: string[] = [];
+
+  ([
+    [TokenType.class, SemanticTokenTypes.class],
+    [TokenType.enum, SemanticTokenTypes.enum],
+    [TokenType.interface, SemanticTokenTypes.interface],
+    [TokenType.namespace, SemanticTokenTypes.namespace],
+    [TokenType.typeParameter, SemanticTokenTypes.typeParameter],
+    [TokenType.type, SemanticTokenTypes.type],
+    [TokenType.parameter, SemanticTokenTypes.parameter],
+    [TokenType.variable, SemanticTokenTypes.variable],
+    [TokenType.enumMember, SemanticTokenTypes.enumMember],
+    [TokenType.property, SemanticTokenTypes.property],
+    [TokenType.function, SemanticTokenTypes.function],
+
+    // member is renamed to method in vscode codebase to match LSP default
+    [TokenType.member, SemanticTokenTypes.method]
+  ] as const).forEach(([tokenType, legend]) => (tokenTypes[tokenType] = legend));
+
+  return {
+    tokenModifiers,
+    tokenTypes
+  };
+}

--- a/server/src/services/projectService.ts
+++ b/server/src/services/projectService.ts
@@ -342,6 +342,12 @@ export async function createProjectService(
       return textDocumentEdit ?? [];
     },
     async onSemanticTokens(params: SemanticTokensParams | SemanticTokensRangeParams) {
+      if (!env.getConfig().vetur.languageFeatures.semanticTokens) {
+        return {
+          data: []
+        };
+      }
+
       const { textDocument } = params;
       const range = 'range' in params ? params.range : undefined;
       const doc = documentService.getDocument(textDocument.uri)!;

--- a/server/src/services/projectService.ts
+++ b/server/src/services/projectService.ts
@@ -64,7 +64,7 @@ export interface ProjectService {
   onCodeAction(params: CodeActionParams): Promise<CodeAction[]>;
   onCodeActionResolve(action: CodeAction): Promise<CodeAction>;
   onWillRenameFile(fileRename: FileRename): Promise<TextDocumentEdit[]>;
-  onSemanticTokens(params: SemanticTokensParams | SemanticTokensRangeParams): Promise<SemanticTokens | null>;
+  onSemanticTokens(params: SemanticTokensParams | SemanticTokensRangeParams): Promise<SemanticTokens>;
   doValidate(doc: TextDocument, cancellationToken?: VCancellationToken): Promise<Diagnostic[] | null>;
   dispose(): Promise<void>;
 }
@@ -356,10 +356,7 @@ export async function createProjectService(
 
       for (const mode of modes) {
         const tokenData = mode.mode.getSemanticTokens?.(doc, range);
-        // all or nothing
-        if (tokenData === null) {
-          return null;
-        }
+
         data.push(...(tokenData ?? []));
       }
 

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -69,7 +69,7 @@ import { getVueVersionKey } from '../utils/vueVersion';
 import { accessSync, constants, existsSync } from 'fs';
 import { sleep } from '../utils/sleep';
 import { URI } from 'vscode-uri';
-import { getSemanticTokenLegends } from '../modes/script/semanticTokenLegend';
+import { getSemanticTokenLegends } from '../modes/script/semanticToken';
 
 interface ProjectConfig {
   vlsFullConfig: VLSFullConfig;

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -26,7 +26,12 @@ import {
   CompletionParams,
   ExecuteCommandParams,
   FoldingRangeParams,
-  RenameFilesParams
+  RenameFilesParams,
+  SemanticTokensParams,
+  SemanticTokens,
+  SemanticTokensRangeParams,
+  SemanticTokensRequest,
+  SemanticTokensRangeRequest
 } from 'vscode-languageserver';
 import {
   ColorInformation,
@@ -44,9 +49,10 @@ import {
   FoldingRange,
   DocumentUri,
   CodeAction,
-  CodeActionKind
+  CodeActionKind,
+  TextDocumentIdentifier
 } from 'vscode-languageserver-types';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { Range, TextDocument } from 'vscode-languageserver-textdocument';
 
 import { NULL_COMPLETION, NULL_HOVER, NULL_SIGNATURE } from '../modes/nullMode';
 import { createDependencyService, createNodeModulesPaths } from './dependencyService';
@@ -63,6 +69,7 @@ import { getVueVersionKey } from '../utils/vueVersion';
 import { accessSync, constants, existsSync } from 'fs';
 import { sleep } from '../utils/sleep';
 import { URI } from 'vscode-uri';
+import { getSemanticTokenLegends } from '../modes/script/semanticTokenLegend';
 
 interface ProjectConfig {
   vlsFullConfig: VLSFullConfig;
@@ -384,6 +391,8 @@ export class VLS {
     this.lspConnection.onCodeAction(this.onCodeAction.bind(this));
     this.lspConnection.onCodeActionResolve(this.onCodeActionResolve.bind(this));
     this.lspConnection.workspace.onWillRenameFiles(this.onWillRenameFiles.bind(this));
+    this.lspConnection.onRequest(SemanticTokensRequest.type, this.onSemanticToken.bind(this));
+    this.lspConnection.onRequest(SemanticTokensRangeRequest.type, this.onSemanticToken.bind(this));
 
     this.lspConnection.onDocumentColor(this.onDocumentColors.bind(this));
     this.lspConnection.onColorPresentation(this.onColorPresentations.bind(this));
@@ -620,6 +629,12 @@ export class VLS {
     };
   }
 
+  async onSemanticToken(params: SemanticTokensParams | SemanticTokensRangeParams): Promise<SemanticTokens | null> {
+    const project = await this.getProjectService(params.textDocument.uri);
+
+    return project?.onSemanticTokens(params) ?? null;
+  }
+
   private triggerValidation(textDocument: TextDocument): void {
     if (textDocument.uri.includes('node_modules')) {
       return;
@@ -713,7 +728,12 @@ export class VLS {
       executeCommandProvider: {
         commands: []
       },
-      foldingRangeProvider: true
+      foldingRangeProvider: true,
+      semanticTokensProvider: {
+        range: true,
+        full: true,
+        legend: getSemanticTokenLegends()
+      }
     };
   }
 }

--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -391,8 +391,8 @@ export class VLS {
     this.lspConnection.onCodeAction(this.onCodeAction.bind(this));
     this.lspConnection.onCodeActionResolve(this.onCodeActionResolve.bind(this));
     this.lspConnection.workspace.onWillRenameFiles(this.onWillRenameFiles.bind(this));
-    this.lspConnection.onRequest(SemanticTokensRequest.type, this.onSemanticToken.bind(this));
-    this.lspConnection.onRequest(SemanticTokensRangeRequest.type, this.onSemanticToken.bind(this));
+    this.lspConnection.languages.semanticTokens.on(this.onSemanticToken.bind(this));
+    this.lspConnection.languages.semanticTokens.onRange(this.onSemanticToken.bind(this));
 
     this.lspConnection.onDocumentColor(this.onDocumentColors.bind(this));
     this.lspConnection.onColorPresentation(this.onColorPresentations.bind(this));
@@ -629,10 +629,10 @@ export class VLS {
     };
   }
 
-  async onSemanticToken(params: SemanticTokensParams | SemanticTokensRangeParams): Promise<SemanticTokens | null> {
+  async onSemanticToken(params: SemanticTokensParams | SemanticTokensRangeParams): Promise<SemanticTokens> {
     const project = await this.getProjectService(params.textDocument.uri);
 
-    return project?.onSemanticTokens(params) ?? null;
+    return project?.onSemanticTokens(params) ?? { data: [] as number[] };
   }
 
   private triggerValidation(textDocument: TextDocument): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,4 +1,3 @@
-import ts from 'typescript';
 import { LanguageId } from './embeddedSupport/embeddedSupport';
 
 export interface DocumentContext {
@@ -48,4 +47,7 @@ export interface SemanticTokenData extends SemanticTokenClassification {
   length: number;
 }
 
-export interface SemanticTokenOffsetData extends SemanticTokenClassification, ts.TextSpan {}
+export interface SemanticTokenOffsetData extends SemanticTokenClassification {
+  start: number;
+  length: number;
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,3 +1,4 @@
+import ts from 'typescript';
 import { LanguageId } from './embeddedSupport/embeddedSupport';
 
 export interface DocumentContext {
@@ -36,10 +37,15 @@ export interface OrganizeImportsActionData extends BaseCodeActionData {
 
 export type CodeActionData = RefactorActionData | CombinedFixActionData | OrganizeImportsActionData;
 
-export interface SemanticTokenData {
-  line: number;
-  character: number;
-  length: number;
+interface SemanticTokenClassification {
   classificationType: number;
   modifierSet: number;
 }
+
+export interface SemanticTokenData extends SemanticTokenClassification {
+  line: number;
+  character: number;
+  length: number;
+}
+
+export interface SemanticTokenOffsetData extends SemanticTokenClassification, ts.TextSpan {}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -35,3 +35,11 @@ export interface OrganizeImportsActionData extends BaseCodeActionData {
 }
 
 export type CodeActionData = RefactorActionData | CombinedFixActionData | OrganizeImportsActionData;
+
+export interface SemanticTokenData {
+  line: number;
+  character: number;
+  length: number;
+  classificationType: number;
+  modifierSet: number;
+}

--- a/test/codeTestRunner.ts
+++ b/test/codeTestRunner.ts
@@ -25,7 +25,7 @@ async function run(execPath: string, testWorkspaceRelativePath: string, mochaArg
 
   return await runTests({
     vscodeExecutablePath: execPath,
-    version: '1.52.1',
+    version: '1.53.2',
     extensionDevelopmentPath: EXT_ROOT,
     extensionTestsPath: extTestPath,
     extensionTestsEnv: mochaArgs,
@@ -81,7 +81,7 @@ function installMissingDependencies(fixturePath: string) {
 }
 
 async function go() {
-  const execPath = await downloadAndUnzipVSCode('1.52.1');
+  const execPath = await downloadAndUnzipVSCode('1.53.2');
   await runAllTests(execPath);
 }
 

--- a/test/lsp/features/semanticTokens/basic.test.ts
+++ b/test/lsp/features/semanticTokens/basic.test.ts
@@ -1,0 +1,159 @@
+import assert from 'assert';
+import vscode from 'vscode';
+import { SemanticTokensRequest, SemanticTokensParams, SemanticTokens, SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-protocol';
+import { sendLSRequest, showFile } from '../../../editorHelper';
+import { sameLineRange } from '../../../util';
+import { getDocUri } from '../../path';
+
+function getTokenRange(line: number, startChar: number, identifier: string) {
+  return sameLineRange(line, startChar, startChar + identifier.length);
+}
+
+describe('Should update import when rename files', () => {
+  const docPath = 'semanticTokens/Basic.vue';
+  const docUri = getDocUri(docPath);
+  it('provide semantic tokens', async () => {
+    await testSemanticTokens(docUri, encodeExpected([
+      {
+        type: SemanticTokenTypes.variable,
+        range: getTokenRange(7, 6, 'aConst'),
+        modifiers: [SemanticTokenModifiers.declaration, SemanticTokenModifiers.readonly],
+      },
+      {
+        type: SemanticTokenTypes.class,
+        range: getTokenRange(9, 15, 'Vue'),
+        modifiers: [],
+      },
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(9, 19, 'extend'),
+        modifiers: [],
+      },
+      {
+        type: SemanticTokenTypes.property,
+        range: getTokenRange(10, 2, 'methods'),
+        modifiers: [SemanticTokenModifiers.declaration]
+      },
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(11, 4, 'abc'),
+        modifiers: [SemanticTokenModifiers.declaration]
+      },
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(12, 11, 'log'),
+        modifiers: []
+      },
+      {
+        type: SemanticTokenTypes.variable,
+        range: getTokenRange(12, 15, 'aConst'),
+        modifiers: [SemanticTokenModifiers.readonly]
+      },
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(14, 4, 'log'),
+        modifiers: [SemanticTokenModifiers.declaration]
+      },
+      {
+        type: SemanticTokenTypes.parameter,
+        range: getTokenRange(14, 8, 'str'),
+        modifiers: [SemanticTokenModifiers.declaration]
+      },
+      {
+        type: SemanticTokenTypes.variable,
+        range: getTokenRange(15, 6, 'console'),
+        modifiers: [SemanticTokenModifiers.defaultLibrary]
+      },
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(15, 14, 'log'),
+        modifiers: [SemanticTokenModifiers.defaultLibrary]
+      },
+      {
+        type: SemanticTokenTypes.parameter,
+        range: getTokenRange(15, 18, 'str'),
+        modifiers: []
+      }
+    ]));
+  });
+
+  async function testSemanticTokens(uri: vscode.Uri, expected: number[], range?: vscode.Range) {
+    await showFile(docUri);
+
+    const result = await sendLSRequest<SemanticTokens>(SemanticTokensRequest.method, {
+      textDocument: {
+        uri: uri.toString(),
+      }
+    } as SemanticTokensParams);
+    assertResult(result!.data, expected);
+  }
+});
+
+/**
+ *  group result by tokens to better distinguish
+ */
+function assertResult(actual: number[], expected: number[]) {
+  const actualGrouped = group(actual);
+  const expectedGrouped = group(expected);
+
+  assert.deepStrictEqual(actualGrouped, expectedGrouped);
+}
+
+function group(tokens: number[]) {
+  const result: number[][] = [];
+
+  let index = 0;
+  while (index < tokens.length) {
+    result.push(Array.from(tokens.slice(index, (index += 5))));
+  }
+
+  return result;
+}
+
+interface UnEncodedSemanticTokenData {
+  range: vscode.Range;
+  type: string;
+  modifiers: string[];
+}
+
+function encodeExpected(tokens: UnEncodedSemanticTokenData[]) {
+  const builder = new vscode.SemanticTokensBuilder(getLegend());
+
+  for (const token of tokens) {    
+    builder.push(
+      token.range,
+      token.type,
+      token.modifiers
+    );
+  }
+
+  return Array.from(builder.build().data);
+}
+
+// TODO: change to use built in command once test target is vscode 1.53
+function getLegend(): vscode.SemanticTokensLegend {
+  return {
+    tokenModifiers: [
+      SemanticTokenModifiers.declaration,
+      SemanticTokenModifiers.static,
+      SemanticTokenModifiers.async,
+      SemanticTokenModifiers.readonly,
+      SemanticTokenModifiers.defaultLibrary,
+      'local'
+    ],
+    tokenTypes: [
+      SemanticTokenTypes.class,
+      SemanticTokenTypes.enum,
+      SemanticTokenTypes.interface,
+      SemanticTokenTypes.namespace,
+      SemanticTokenTypes.typeParameter,
+      SemanticTokenTypes.type,
+      SemanticTokenTypes.parameter,
+      SemanticTokenTypes.variable,
+      SemanticTokenTypes.enumMember,
+      SemanticTokenTypes.property,
+      SemanticTokenTypes.function,
+      SemanticTokenTypes.method
+    ]
+  };
+}

--- a/test/lsp/fixture/semanticTokens/Basic.vue
+++ b/test/lsp/fixture/semanticTokens/Basic.vue
@@ -1,0 +1,20 @@
+<template>
+  <div></div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+const aConst = 'SOME_STORE';
+
+export default Vue.extend({
+  methods: {
+    abc() {
+      this.log(aConst)
+    },
+    log(str: string) {
+      console.log(str);
+    }
+  }
+})
+</script>

--- a/test/semanticTokenHelper.ts
+++ b/test/semanticTokenHelper.ts
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import vscode from 'vscode';
+import { showFile } from './editorHelper';
+import { sameLineRange } from './util';
+
+/**
+ *  group result by tokens to better distinguish
+ */
+export function assertResult(actual: Uint32Array, expected: number[]) {
+  const actualGrouped = group(actual);
+  const expectedGrouped = group(expected);
+
+  assert.deepStrictEqual(actualGrouped, expectedGrouped);
+}
+
+function group(tokens: Uint32Array | number[]) {
+  const result: number[][] = [];
+
+  let index = 0;
+  while (index < tokens.length) {
+    result.push(Array.from(tokens.slice(index, (index += 5))));
+  }
+
+  return result;
+}
+
+export interface UnEncodedSemanticTokenData {
+  range: vscode.Range;
+  type: string;
+  modifiers: string[];
+}
+
+function encodeExpected(legend: vscode.SemanticTokensLegend, tokens: UnEncodedSemanticTokenData[]) {
+  const builder = new vscode.SemanticTokensBuilder(legend);
+
+  for (const token of tokens) {
+    builder.push(token.range, token.type, token.modifiers);
+  }
+
+  return Array.from(builder.build().data);
+}
+
+async function getLegend(uri: vscode.Uri): Promise<vscode.SemanticTokensLegend> {
+  const res = await vscode.commands.executeCommand<vscode.SemanticTokensLegend>(
+    'vscode.provideDocumentSemanticTokensLegend',
+    uri
+  );
+
+  return res!;
+}
+
+export async function testSemanticTokens(docUri: vscode.Uri, expected: UnEncodedSemanticTokenData[]) {
+  await showFile(docUri);
+
+  const result = await vscode.commands.executeCommand<vscode.SemanticTokens>(
+    'vscode.provideDocumentSemanticTokens',
+    docUri
+  );
+  assertResult(result!.data, encodeExpected(await getLegend(docUri), expected));
+}
+
+export function getTokenRange(line: number, startChar: number, identifier: string) {
+  return sameLineRange(line, startChar, startChar + identifier.length);
+}

--- a/test/vue3/features/semanticTokens/basic.test.ts
+++ b/test/vue3/features/semanticTokens/basic.test.ts
@@ -1,0 +1,38 @@
+import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-protocol';
+import { getTokenRange, testSemanticTokens } from '../../../semanticTokenHelper';
+import { getDocUri } from '../../path';
+
+describe('semantic tokens', () => {
+  const docPath = 'semanticTokens/Basic.vue';
+  const docUri = getDocUri(docPath);
+
+  it('provide semantic tokens', async () => {
+    await testSemanticTokens(docUri, [
+      {
+        type: SemanticTokenTypes.method,
+        range: getTokenRange(7, 2, 'setup'),
+        modifiers: [SemanticTokenModifiers.declaration]
+      },
+      {
+        type: SemanticTokenTypes.variable,
+        range: getTokenRange(8, 10, 'a'),
+        modifiers: [SemanticTokenModifiers.readonly, SemanticTokenModifiers.declaration, 'local']
+      },
+      {
+        type: SemanticTokenTypes.function,
+        range: getTokenRange(8, 14, 'ref'),
+        modifiers: []
+      },
+      {
+        type: SemanticTokenTypes.variable,
+        range: getTokenRange(10, 4, 'a'),
+        modifiers: [SemanticTokenModifiers.readonly, 'local']
+      },
+      {
+        type: SemanticTokenTypes.property,
+        range: getTokenRange(10, 6, 'value'),
+        modifiers: ['refValue']
+      }
+    ]);
+  });
+});

--- a/test/vue3/fixture/semanticTokens/Basic.vue
+++ b/test/vue3/fixture/semanticTokens/Basic.vue
@@ -1,0 +1,14 @@
+<template>
+  <div></div>
+</template>
+
+<script lang="ts">
+import { ref } from 'vue'
+export default {
+  setup() {
+    const a = ref('')
+
+    a.value
+  },
+}
+</script>


### PR DESCRIPTION
Fixed #1904
Fixed #2687
Fixed #2434
Fixed #2687

### implentation 

Add semantic token feature for script region. Due to typescript's implementation. It's currently not available for js. Also because of that, this is currently not available in interpolation mode. But I still left some merging strategy in the project service for potential future implementation. 

A couple of things like to discuss. 

1. There's some new built-in vscode command in [1.53](https://code.visualstudio.com/updates/v1_53#_semantic-token-commands)
Wondering if I should update the integration test to use it. The advantage is it's more integrated than a language-server request. And  I don't have to copy the semantic token legend to the test script. A disadvantage is we might accidentally ship features not compatible with 1.52.  

2. Computed member is highlighted as a method. Should we need to override it?

### screenshot
Here is some screenshot comparison. The theme is GitHub dark.
Without semantic tokens
![圖片](https://user-images.githubusercontent.com/36730922/112081287-620d0680-8bbe-11eb-9b52-250ef99244b7.png)

With semantic tokens
![圖片](https://user-images.githubusercontent.com/36730922/112081236-4a358280-8bbe-11eb-9c8f-4e33bab5d786.png)

Without 
![圖片](https://user-images.githubusercontent.com/36730922/112083866-cd58d780-8bc2-11eb-98a3-70c08a089968.png)

With
![圖片](https://user-images.githubusercontent.com/36730922/112083815-b1edcc80-8bc2-11eb-8445-5c7a9fbfd08c.png)
