### PR TITLE
add paths option to vti diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `--log-level` option for `vti diagnostics` to configure log level to print. #2752.
 - 🙌 Semantic tokens for typescript and highlight `.value` if using composition API. Thanks to contribution from [@jasonlyu123](https://github.com/jasonlyu123). #2802 #1904 # 2434
+- Add paths option for `vti diagnostics` to diagnose only sub files or directories. #2455.
 
 ### 0.33.1 | 2021-03-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.1/vspackage)
 

--- a/vti/src/cli.ts
+++ b/vti/src/cli.ts
@@ -15,7 +15,7 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
   program.name('vti').description('Vetur Terminal Interface').version(getVersion());
 
   program
-    .command('diagnostics [workspace]')
+    .command('diagnostics [workspace] [paths...]')
     .description('Print all diagnostics')
     .addOption(
       new Option('-l, --log-level <logLevel>', 'Log level to print')
@@ -23,12 +23,12 @@ function validateLogLevel(logLevelInput: unknown): logLevelInput is LogLevel {
         // logLevels is readonly array but .choices need read-write array (because of weak typing)
         .choices((logLevels as unknown) as string[])
     )
-    .action(async (workspace, options) => {
+    .action(async (workspace, paths, options) => {
       const logLevelOption: unknown = options.logLevel;
       if (!validateLogLevel(logLevelOption)) {
         throw new Error(`Invalid log level: ${logLevelOption}`);
       }
-      await diagnostics(workspace, logLevelOption);
+      await diagnostics(workspace, paths, logLevelOption);
     });
 
   program.parse(process.argv);


### PR DESCRIPTION
Resolves https://github.com/vuejs/vetur/issues/2455

`vti diagnostics --files src/App.vue src/Form.vue` to run VTI only on those two files

```
$ vti diagnostics --help
Usage: vti diagnostics [options] [workspace]

Print all diagnostics

Options:
  -l, --log-level <logLevel>  Log level to print (choices: "ERROR", "WARN", "INFO", "HINT", default: "WARN")
  -f, --files <files...>      Files to diagnose (default: null)
  -h, --help                  display help for command
```