### PR TITLE
Add TypeScript language server support for Vucipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add `--log-level` option for `vti diagnostics` to configure log level to print. #2752.
 - 🙌 Semantic tokens for typescript and highlight `.value` if using composition API. Thanks to contribution from [@jasonlyu123](https://github.com/jasonlyu123). #2802 #1904 # 2434
-
+- Add Vucript language server support
 ### 0.33.1 | 2021-03-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.33.1/vspackage)
 
 - 🙌 Added new ts and js snippets for the Composition API. Thanks to contribution from [@Namchee](https://github.com/Namchee). #2741

--- a/server/src/embeddedSupport/vueDocumentRegionParser.ts
+++ b/server/src/embeddedSupport/vueDocumentRegionParser.ts
@@ -269,5 +269,8 @@ function getLanguageIdFromLangAttr(lang: string): LanguageId {
   if (languageIdFromType === 'ts') {
     languageIdFromType = 'typescript';
   }
+  if (languageIdFromType === 'vucript') {
+    languageIdFromType = 'typescript';
+  }
   return languageIdFromType as LanguageId;
 }


### PR DESCRIPTION
## Background
I’m currently developing a typescript dialect called [vucript](https://github.com/vucript-ts/vucript) which makes Vue component code much shorter .
With [vue-cli-plugin-vucript](https://github.com/vucript-ts/vue-cli-plugin-vucript), you can write vucript to your Vue SFC by adding `lang=’vucript’` to your script block like typescript.
## Feature
My commits enables typescript language server to work even on script block with `lang=‘vucript’`.
It makes vucript development much easier.

<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->