### PR TITLE
Fix component data not shown in hover when template interpolation is on

### DIFF
--- a/test/componentData/features/hover/basic.test.ts
+++ b/test/componentData/features/hover/basic.test.ts
@@ -1,0 +1,30 @@
+import { testHover } from '../../../hoverHelper';
+import { position, sameLineRange } from '../../../util';
+import { getDocUri } from '../../path';
+
+describe('Should show hover info with component data', () => {
+  const docUri = getDocUri('hover/Element.vue');
+
+  it('shows element description', async () => {
+    await testHover(docUri, position(2, 5), {
+      contents: [
+        '```ts\n(property) __vlsComponentData<Record<string, any>>.props: Record<string, any>\n```\nA foo tag'
+      ],
+      range: sameLineRange(2, 5, 12)
+    });
+  });
+
+  it('shows attribute description for non-dynamic attribute', async () => {
+    await testHover(docUri, position(2, 15), {
+      contents: ['An foo-attr description'],
+      range: sameLineRange(2, 13, 21)
+    });
+  });
+
+  it('shows attribute description for dynamic attribute with template interpolation enabled', async () => {
+    await testHover(docUri, position(3, 15), {
+      contents: ['```ts\n(property) "foo-attr": string\n```\nAn foo-attr description'],
+      range: sameLineRange(3, 14, 22)
+    });
+  });
+});

--- a/test/componentData/fixture/.vscode/settings.json
+++ b/test/componentData/fixture/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "vetur.experimental.templateInterpolationService": true
+}

--- a/test/componentData/fixture/attributes.json
+++ b/test/componentData/fixture/attributes.json
@@ -1,4 +1,7 @@
 {
+  "foo-tag/foo-attr": {
+    "description": "An foo-attr description"
+  },
   "handle-foo": {
     "type": "event",
     "documentation": "You gotta handle foo"

--- a/test/componentData/fixture/hover/Element.vue
+++ b/test/componentData/fixture/hover/Element.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <foo-tag foo-attr="v" />
+    <foo-tag :foo-attr="'v'" />
+  </div>
+</template>

--- a/test/componentData/fixture/package.json
+++ b/test/componentData/fixture/package.json
@@ -8,7 +8,7 @@
     "element-ui": "^2.13.2"
   },
   "vetur": {
-    "tags": "./tags.json",
-    "attributes": "./attributes.json"
+    "attributes": "./attributes.json",
+    "tags": "./tags.json"
   }
 }

--- a/test/interpolation/features/hover/basic.test.ts
+++ b/test/interpolation/features/hover/basic.test.ts
@@ -7,21 +7,21 @@ describe('Should do hover interpolation for <template>', () => {
 
   it('shows hover for msg in mustache', async () => {
     await testHover(docUri, position(2, 11), {
-      contents: ['\n```ts\n(property) msg: string\n```\n'],
+      contents: ['```ts\n(property) msg: string\n```'],
       range: sameLineRange(2, 10, 13)
     });
   });
 
   it('shows hover for v-for variable', async () => {
     await testHover(docUri, position(5, 20), {
-      contents: ['\n```ts\n(parameter) item: number\n```\n'],
+      contents: ['```ts\n(parameter) item: number\n```'],
       range: sameLineRange(5, 18, 22)
     });
   });
 
   it('shows hover for v-for variable on readonly array', async () => {
     await testHover(docUri, position(10, 20), {
-      contents: ['\n```ts\n(parameter) item: string\n```\n'],
+      contents: ['```ts\n(parameter) item: string\n```'],
       range: sameLineRange(10, 18, 22)
     });
   });


### PR DESCRIPTION
In cases where template interpolation provided some data for the hover
popup, it overrode the popup contents without letting component data
hover info to show.

Ask both services and merge the results together so that nothing is
lost.

Fixes #2878

<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->