### PR TITLE
Update snippet.md so that images are rendered

### DIFF
--- a/docs/guide/snippet.md
+++ b/docs/guide/snippet.md
@@ -36,7 +36,7 @@ To start using them, type:
 
 Three sources supplement Vetur with scaffold snippets:
 
-![Snippet Main](/images/snippet-main.png)
+![Snippet Main](../images/snippet-main.png)
 
 - 💼 Workspace. Located at `<WORKSPACE>/.vscode/vetur/snippets`. These scaffold snippets are only available in the workspace.
 - 🗒️ User data directory. You can open the folder with the command `Vetur: Open user scaffold snippet folder`. These scaffold snippets are available in all workspaces.
@@ -68,7 +68,7 @@ You can customize the suffix and turn sources on/off with `vetur.completion.scaf
 }
 ```
 
-![Snippet Partial](/images/snippet-partial.png)
+![Snippet Partial](../images/snippet-partial.png)
 
 #### Snippet Syntax
 


### PR DESCRIPTION
<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->

### What does this PR do?

Fixes #2927 

### Description of Task to be completed?

The command `npx vuepress build` (in `build/update-docs.sh`) is not bundling the images since the image link in the `docs/guide/snippet.md` is not relative for both the:
- `docs/images/snippet-main.png` _line 39_
- `docs/images/snippet-partial.png` _line 71_

images.

### How should this be manually tested?

I've tested that my changes work, see the rendered page [here](https://code.stanmd.tk/vetur/guide/snippet.html#customizable-scaffold-snippets). (I'm using GitHub pages just like the project is)

### Screenshots

<img width="924" alt="Screenshot 2021-05-11 at 09 52 08" src="https://user-images.githubusercontent.com/15629602/117771325-a6bc3200-b23e-11eb-82fa-479ee9035b88.png">

#### Questions:

Are the other images in the `docs/images` folder still being used? That is:
- `docs/images/scope.png`
- `docs/images/debug.png`

If not, I guess they should be deleted. I didn't see them referenced anywhere in the project.
