### PR TITLE
Update project root shorthand comment

### DIFF
--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -137,7 +137,7 @@ module.exports = {
   // **optional** default: `[{ root: './' }]`
   // support monorepos
   projects: [
-    './packages/repo2', // shorthand for only root.
+    './packages/repo2', // Shorthand for specifying only the project root location
     {
       // **required**
       // Where is your project?


### PR DESCRIPTION
The existing comment ("// shorthand for only root") confused me: I thought it meant there was only one project root, not that only the root is being specified.

<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->