### PR TITLE
fix: broken links "semantic-highlighting" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Thanks to the following companies for supporting Vetur's development:
 ## Features
 
 - [Syntax-highlighting](https://vuejs.github.io/vetur/guide/highlighting.html)
-- [Semantic-highlighting](https://vuejs.github.io/vetur/guide/semantic-highlighting.md)
+- [Semantic-highlighting](https://vuejs.github.io/vetur/guide/semantic-highlighting.html)
 - [Snippet](https://vuejs.github.io/vetur/guide/snippet.html)
 - [Emmet](https://vuejs.github.io/vetur/guide/emmet.html)
 - [Linting / Error Checking](https://vuejs.github.io/vetur/guide/linting-error.html)


### PR DESCRIPTION
There was a broken link (link error), which has been corrected.