### PR TITLE
fix(docs): delete 'docs' in some links in FAQ page (ISSUE: #2987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.34.2 | 2021-06-07 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.34.2/vspackage)
+
+- Fix: delete 'docs' in some links in FAQ page. #2987
+
 ### 0.34.1 | 2021-06-04 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.34.1/vspackage)
 
 - Fix formatting failed when typescript block with prettier. #2982

--- a/docs/guide/FAQ.md
+++ b/docs/guide/FAQ.md
@@ -128,8 +128,8 @@ Vetur will use fallback settings. Some features such as including path alias, de
 
 You can add this config in correct position in your project or use `vetur.config.js` to set the file path.
 
-- [Read more project setup](/docs/guide/setup.md#project-setup)
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more project setup](/guide/setup.md#project-setup)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debug info, you can use `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode setting to close this warning.
@@ -144,18 +144,18 @@ If the version is wrong, you will get wrong diagnostics from typescript and esli
 
 You can add this config at the correct position in your project or use `vetur.config.js` to set file path.
 
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debug info, you can use `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode setting to close this warning.
 
 ## Vetur found xxx, but they aren\'t in the project root.
 Vetur found the file, but it may not actually be what you want.
-If it is wrong, it will cause same result as the previous two. [ref1](/docs/guide/FAQ.md#vetur-can-t-find-tsconfig-json-jsconfig-json-in-xxxx-xxxxxx), [ref2](/docs/guide/FAQ.md#vetur-can-t-find-package-json-in-xxxx-xxxxxx)
+If it is wrong, it will cause same result as the previous two. [ref1](/guide/FAQ.md#vetur-can-t-find-tsconfig-json-jsconfig-json-in-xxxx-xxxxxx), [ref2](/guide/FAQ.md#vetur-can-t-find-package-json-in-xxxx-xxxxxx)
 
 You can add this config at the correct position in your project or use `vetur.config.js` to set file path.
 
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debugging info, you can use the `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode settings to close this warning.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vue tooling for VS Code",
   "author": "Pine Wu <octref@gmail.com>",
   "icon": "asset/vue.png",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "publisher": "octref",
   "scripts": {
     "postinstall": "run-s install:*",


### PR DESCRIPTION
[What is] This fixes a mistake about of the documentation about hrefs in FAQs pge.
[Issue] #2987
[URL] https://vuejs.github.io/vetur/guide/FAQ.html

