### PR TITLE
Fix broken links in FAQ by removing /docs

### DIFF
--- a/docs/guide/FAQ.md
+++ b/docs/guide/FAQ.md
@@ -128,8 +128,8 @@ Vetur will use fallback settings. Some features such as including path alias, de
 
 You can add this config in correct position in your project or use `vetur.config.js` to set the file path.
 
-- [Read more project setup](/docs/guide/setup.md#project-setup)
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more project setup](/guide/setup.md#project-setup)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debug info, you can use `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode setting to close this warning.
@@ -144,18 +144,18 @@ If the version is wrong, you will get wrong diagnostics from typescript and esli
 
 You can add this config at the correct position in your project or use `vetur.config.js` to set file path.
 
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debug info, you can use `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode setting to close this warning.
 
 ## Vetur found xxx, but they aren\'t in the project root.
 Vetur found the file, but it may not actually be what you want.
-If it is wrong, it will cause same result as the previous two. [ref1](/docs/guide/FAQ.md#vetur-can-t-find-tsconfig-json-jsconfig-json-in-xxxx-xxxxxx), [ref2](/docs/guide/FAQ.md#vetur-can-t-find-package-json-in-xxxx-xxxxxx)
+If it is wrong, it will cause same result as the previous two. [ref1](/guide/FAQ.md#vetur-can-t-find-tsconfig-json-jsconfig-json-in-xxxx-xxxxxx), [ref2](/guide/FAQ.md#vetur-can-t-find-package-json-in-xxxx-xxxxxx)
 
 You can add this config at the correct position in your project or use `vetur.config.js` to set file path.
 
-- [Read more `vetur.config.js`](/docs/guide/setup.md#advanced)
+- [Read more `vetur.config.js`](/guide/setup.md#advanced)
 
 If you want debugging info, you can use the `Vetur: show doctor info` command.   
 You can use `vetur.ignoreProjectWarning: true` in vscode settings to close this warning.


### PR DESCRIPTION
There are some broken links in the FAQ page of the docs. This should fix them!

I tested it manually in the browser, not locally with the new urls.