### PR TITLE
Improve IntelliSense for component attributes/emits

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,6 +270,19 @@
           ],
           "description": "Casing conversion for tag completion"
         },
+        "vetur.completion.attributeCasing": {
+          "type": "string",
+          "default": "kebab",
+          "enum": [
+            "camel",
+            "kebab"
+          ],
+          "enumDescriptions": [
+            "camelCase completion for <... myAttribute>",
+            "kebab-case completion for <... my-attribute>"
+          ],
+          "description": "Casing conversion for :prop and @event attribute completion"
+        },
         "vetur.grammar.customBlocks": {
           "type": "object",
           "default": {

--- a/server/src/embeddedSupport/languageModes.ts
+++ b/server/src/embeddedSupport/languageModes.ts
@@ -43,11 +43,13 @@ import { createAutoImportSfcPlugin } from '../modes/plugins/autoImportSfcPlugin'
 import { EnvironmentService } from '../services/EnvironmentService';
 import { FileRename } from 'vscode-languageserver';
 import { RefTokensService } from '../services/RefTokenService';
+import { DocumentService } from '../services/documentService';
 
 export interface VLSServices {
   dependencyService: DependencyService;
   infoService: VueInfoService;
   refTokensService: RefTokensService;
+  documentService: DocumentService;
 }
 
 export interface LanguageMode {
@@ -69,7 +71,7 @@ export interface LanguageMode {
   findDocumentHighlight?(document: TextDocument, position: Position): DocumentHighlight[];
   findDocumentSymbols?(document: TextDocument): SymbolInformation[];
   findDocumentLinks?(document: TextDocument, documentContext: DocumentContext): DocumentLink[];
-  findDefinition?(document: TextDocument, position: Position): Definition;
+  findDefinition?(document: TextDocument, position: Position, documentService: DocumentService): Definition;
   findReferences?(document: TextDocument, position: Position): Location[];
   format?(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[];
   findDocumentColors?(document: TextDocument): ColorInformation[];
@@ -141,6 +143,7 @@ export class LanguageModes {
       this.documentRegions,
       autoImportSfcPlugin,
       services.dependencyService,
+      services.documentService,
       services.infoService
     );
 

--- a/server/src/modes/script/childComponents.ts
+++ b/server/src/modes/script/childComponents.ts
@@ -91,14 +91,25 @@ export function analyzeComponentsDefine(
           return;
         }
 
+        const definition = {
+          start: 0,
+          end: 0,
+          path: sourceFile.fileName
+        };
+
+        // If export node is equal to '{}' it means that the vue file doesn't have <script> component.
+        if (
+          defaultExportNode.kind !== tsModule.SyntaxKind.ObjectLiteralExpression ||
+          defaultExportNode.getText() !== '{}'
+        ) {
+          definition.start = defaultExportNode.getStart(sourceFile, true);
+          definition.end = defaultExportNode.getEnd();
+        }
+
         result.push({
           name: componentName,
           documentation: buildDocumentation(tsModule, definitionSymbol, checker),
-          definition: {
-            path: sourceFile.fileName,
-            start: defaultExportNode.getStart(sourceFile, true),
-            end: defaultExportNode.getEnd()
-          },
+          definition,
           defaultExportNode
         });
       }

--- a/server/src/modes/script/childComponents.ts
+++ b/server/src/modes/script/childComponents.ts
@@ -98,10 +98,7 @@ export function analyzeComponentsDefine(
         };
 
         // If export node is equal to '{}' it means that the vue file doesn't have <script> component.
-        if (
-          defaultExportNode.kind !== tsModule.SyntaxKind.ObjectLiteralExpression ||
-          defaultExportNode.getText() !== '{}'
-        ) {
+        if (!tsModule.isObjectLiteralExpression(defaultExportNode) || defaultExportNode.properties.length > 0) {
           definition.start = defaultExportNode.getStart(sourceFile, true);
           definition.end = defaultExportNode.getEnd();
         }

--- a/server/src/modes/script/componentInfo.ts
+++ b/server/src/modes/script/componentInfo.ts
@@ -240,8 +240,8 @@ function getEmits(
       };
 
       if (emit.decorators && emit.decorators.length > 0) {
-        location.end = emit.decorators[0].expression.end ?? 0;
-        location.start = emit.decorators[0].expression.pos ?? 0;
+        location.end = emit.decorators[0].expression.getEnd() ?? 0;
+        location.start = emit.decorators[0].expression.getStart() ?? 0;
       }
 
       let typeString: string | undefined = undefined;
@@ -311,8 +311,8 @@ function getEmits(
               emitsDeclaration.parent.getFullText().trim()
             )}\n\`\`\`\n`,
             location: {
-              start: emitsDeclaration.pos,
-              end: emitsDeclaration.end
+              start: emitsDeclaration.getStart(),
+              end: emitsDeclaration.getEnd()
             }
           };
         });
@@ -345,8 +345,8 @@ function getEmits(
           ...status,
           documentation: buildDocumentation(tsModule, s, checker),
           location: {
-            start: node?.pos ?? 0,
-            end: node?.end ?? 0
+            start: node?.getStart() ?? 0,
+            end: node?.getEnd() ?? 0
           }
         };
       });
@@ -535,8 +535,8 @@ function getProps(
       };
 
       if (prop.decorators && prop.decorators.length > 0) {
-        location.end = prop.decorators[0].expression.end ?? 0;
-        location.start = prop.decorators[0].expression.pos ?? 0;
+        location.end = prop.decorators[0].expression.getEnd() ?? 0;
+        location.start = prop.decorators[0].expression.getStart() ?? 0;
       }
 
       if (decoratorName === 'PropSync' && tsModule.isStringLiteral(firstNode)) {
@@ -586,8 +586,8 @@ function getProps(
               propsDeclaration.parent.getFullText().trim()
             )}\n\`\`\`\n`,
             location: {
-              start: expr.pos,
-              end: expr.end
+              start: expr.getStart(),
+              end: expr.getEnd()
             }
           };
         });
@@ -621,8 +621,8 @@ function getProps(
           isBoundToModel: false,
           documentation: buildDocumentation(tsModule, s, checker),
           location: {
-            start: node?.pos ?? -1,
-            end: node?.end ?? -1
+            start: node?.getStart() ?? -1,
+            end: node?.getEnd() ?? -1
           }
         };
       });

--- a/server/src/modes/script/javascript.ts
+++ b/server/src/modes/script/javascript.ts
@@ -39,7 +39,7 @@ import { URI } from 'vscode-uri';
 import type ts from 'typescript';
 import _ from 'lodash';
 
-import { nullMode, NULL_SIGNATURE } from '../nullMode';
+import { NULL_SIGNATURE } from '../nullMode';
 import { BasicComponentInfo, VLSFormatConfig } from '../../config';
 import { VueInfoService } from '../../services/vueInfoService';
 import { getComponentInfo } from './componentInfo';

--- a/server/src/modes/template/htmlMode.ts
+++ b/server/src/modes/template/htmlMode.ts
@@ -30,6 +30,7 @@ import { DependencyService } from '../../services/dependencyService';
 import { isVCancellationRequested, VCancellationToken } from '../../utils/cancellationToken';
 import { AutoImportSfcPlugin } from '../plugins/autoImportSfcPlugin';
 import { EnvironmentService } from '../../services/EnvironmentService';
+import { DocumentService } from '../../services/documentService';
 
 export class HTMLMode implements LanguageMode {
   private tagProviderSettings: CompletionConfiguration;
@@ -103,6 +104,11 @@ export class HTMLMode implements LanguageMode {
     const embedded = this.embeddedDocuments.refreshAndGet(document);
     const tagProviders: IHTMLTagProvider[] = [...this.enabledTagProviders];
 
+    const info = this.vueInfoService ? this.vueInfoService.getInfo(document) : undefined;
+    if (info && info.componentInfo.childComponents) {
+      tagProviders.push(getComponentInfoTagProvider(info.componentInfo.childComponents));
+    }
+
     return doHover(embedded, position, this.vueDocuments.refreshAndGet(embedded), tagProviders);
   }
   findDocumentHighlight(document: TextDocument, position: Position) {
@@ -117,10 +123,10 @@ export class HTMLMode implements LanguageMode {
   format(document: TextDocument, range: Range, formattingOptions: FormattingOptions) {
     return htmlFormat(this.dependencyService, document, range, this.env.getConfig().vetur.format as VLSFormatConfig);
   }
-  findDefinition(document: TextDocument, position: Position) {
+  findDefinition(document: TextDocument, position: Position, documentService: DocumentService) {
     const embedded = this.embeddedDocuments.refreshAndGet(document);
     const info = this.vueInfoService ? this.vueInfoService.getInfo(document) : undefined;
-    return findDefinition(embedded, position, this.vueDocuments.refreshAndGet(embedded), info);
+    return findDefinition(embedded, position, this.vueDocuments.refreshAndGet(embedded), documentService, info);
   }
   getFoldingRanges(document: TextDocument) {
     const embedded = this.embeddedDocuments.refreshAndGet(document);

--- a/server/src/modes/template/index.ts
+++ b/server/src/modes/template/index.ts
@@ -13,6 +13,7 @@ import { DependencyService, RuntimeLibrary } from '../../services/dependencyServ
 import { VCancellationToken } from '../../utils/cancellationToken';
 import { AutoImportSfcPlugin } from '../plugins/autoImportSfcPlugin';
 import { EnvironmentService } from '../../services/EnvironmentService';
+import { DocumentService } from '../../services/documentService';
 
 type DocumentRegionCache = LanguageModelCache<VueDocumentRegions>;
 
@@ -20,6 +21,7 @@ export class VueHTMLMode implements LanguageMode {
   private htmlMode: HTMLMode;
   private vueInterpolationMode: VueInterpolationMode;
   private autoImportSfcPlugin: AutoImportSfcPlugin;
+  private documentService: DocumentService;
 
   constructor(
     tsModule: RuntimeLibrary['typescript'],
@@ -28,6 +30,7 @@ export class VueHTMLMode implements LanguageMode {
     documentRegions: DocumentRegionCache,
     autoImportSfcPlugin: AutoImportSfcPlugin,
     dependencyService: DependencyService,
+    documentService: DocumentService,
     vueInfoService?: VueInfoService
   ) {
     const vueDocuments = getLanguageModelCache<HTMLDocument>(10, 60, document => parseHTMLDocument(document));
@@ -41,6 +44,7 @@ export class VueHTMLMode implements LanguageMode {
     );
     this.vueInterpolationMode = new VueInterpolationMode(tsModule, serviceHost, env, vueDocuments, vueInfoService);
     this.autoImportSfcPlugin = autoImportSfcPlugin;
+    this.documentService = documentService;
   }
   getId() {
     return 'vue-html';
@@ -118,7 +122,7 @@ export class VueHTMLMode implements LanguageMode {
     return this.vueInterpolationMode.findReferences(document, position);
   }
   findDefinition(document: TextDocument, position: Position) {
-    const htmlDefinition = this.htmlMode.findDefinition(document, position);
+    const htmlDefinition = this.htmlMode.findDefinition(document, position, this.documentService);
 
     return htmlDefinition.length > 0 ? htmlDefinition : this.vueInterpolationMode.findDefinition(document, position);
   }

--- a/server/src/modes/template/parser/htmlParser.ts
+++ b/server/src/modes/template/parser/htmlParser.ts
@@ -77,9 +77,7 @@ export function parse(text: string): HTMLDocument {
   let endTagStart = -1;
   let pendingAttribute = '';
   let token = scanner.scan();
-  let startPos = -1;
-  let endPos = -1;
-  let attributes: { [name: string]: string } | undefined = {};
+  let attributes: { [k: string]: string } | undefined = {};
   while (token !== TokenType.EOS) {
     switch (token) {
       case TokenType.StartTagOpen:
@@ -139,8 +137,6 @@ export function parse(text: string): HTMLDocument {
         break;
       case TokenType.AttributeName:
         pendingAttribute = scanner.getTokenText();
-        startPos = scanner.getTokenOffset();
-        endPos = scanner.getTokenEnd();
         attributes = curr.attributes;
         if (!attributes) {
           curr.attributes = attributes = {};
@@ -149,8 +145,6 @@ export function parse(text: string): HTMLDocument {
         break;
       case TokenType.AttributeValue:
         const value = scanner.getTokenText();
-        startPos = scanner.getTokenOffset();
-        endPos = scanner.getTokenEnd();
         if (attributes && pendingAttribute) {
           attributes[pendingAttribute] = value;
           pendingAttribute = '';

--- a/server/src/modes/template/parser/htmlParser.ts
+++ b/server/src/modes/template/parser/htmlParser.ts
@@ -77,7 +77,9 @@ export function parse(text: string): HTMLDocument {
   let endTagStart = -1;
   let pendingAttribute = '';
   let token = scanner.scan();
-  let attributes: { [k: string]: string } | undefined = {};
+  let startPos = -1;
+  let endPos = -1;
+  let attributes: { [name: string]: string } | undefined = {};
   while (token !== TokenType.EOS) {
     switch (token) {
       case TokenType.StartTagOpen:
@@ -137,6 +139,8 @@ export function parse(text: string): HTMLDocument {
         break;
       case TokenType.AttributeName:
         pendingAttribute = scanner.getTokenText();
+        startPos = scanner.getTokenOffset();
+        endPos = scanner.getTokenEnd();
         attributes = curr.attributes;
         if (!attributes) {
           curr.attributes = attributes = {};
@@ -145,6 +149,8 @@ export function parse(text: string): HTMLDocument {
         break;
       case TokenType.AttributeValue:
         const value = scanner.getTokenText();
+        startPos = scanner.getTokenOffset();
+        endPos = scanner.getTokenEnd();
         if (attributes && pendingAttribute) {
           attributes[pendingAttribute] = value;
           pendingAttribute = '';

--- a/server/src/modes/template/services/htmlDefinition.ts
+++ b/server/src/modes/template/services/htmlDefinition.ts
@@ -1,10 +1,12 @@
 import { HTMLDocument } from '../parser/htmlParser';
 import { TokenType, createScanner } from '../parser/htmlScanner';
 import { Range, Position, Location } from 'vscode-languageserver-types';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { VueFileInfo } from '../../../services/vueInfoService';
 import { URI } from 'vscode-uri';
 import { kebabCase } from 'lodash';
+import { DocumentService } from '../../../services/documentService';
+import fs from 'fs';
 
 const TRIVIAL_TOKEN = [TokenType.StartTagOpen, TokenType.EndTagOpen, TokenType.Whitespace];
 
@@ -12,6 +14,7 @@ export function findDefinition(
   document: TextDocument,
   position: Position,
   htmlDocument: HTMLDocument,
+  documentService: DocumentService,
   vueFileInfo?: VueFileInfo
 ): Location[] {
   const offset = document.offsetAt(position);
@@ -23,22 +26,105 @@ export function findDefinition(
   function getTagDefinition(tag: string, range: Range, open: boolean): Location[] {
     if (vueFileInfo && vueFileInfo.componentInfo.childComponents) {
       for (const cc of vueFileInfo.componentInfo.childComponents) {
-        if (![tag, tag.toLowerCase(), kebabCase(tag)].includes(cc.name)) {
+        if (![tag, tag.toLowerCase(), kebabCase(tag)].includes(kebabCase(cc.name))) {
           continue;
         }
         if (!cc.definition) {
           continue;
         }
 
+        const fileUri = URI.file(cc.definition.path).toString();
+        const targetDocument = getDocumentByFileUriSchemeOrPath(cc.definition.path, fileUri);
+
+        let range: Range | null = null;
+
+        if (targetDocument) {
+          range = Range.create(
+            targetDocument.positionAt(cc.definition.start),
+            targetDocument.positionAt(cc.definition.end)
+          );
+        }
+
         const loc: Location = {
           uri: URI.file(cc.definition.path).toString(),
-          // Todo: Resolve actual default export range
-          range: Range.create(0, 0, 0, 0)
+          range: range ?? Range.create(0, 0, 0, 0)
         };
         return [loc];
       }
     }
     return [];
+  }
+
+  function getAttributeDefinition(tagName: string, attributeName: string): Location[] {
+    tagName = kebabCase(tagName);
+
+    if (vueFileInfo && vueFileInfo.componentInfo.childComponents) {
+      for (const cc of vueFileInfo.componentInfo.childComponents) {
+        if (
+          !cc.definition ||
+          !cc.info ||
+          !cc.info.componentInfo ||
+          (cc.name !== tagName && kebabCase(cc.name) !== tagName)
+        ) {
+          continue;
+        }
+
+        let targetDocument: TextDocument | null = null;
+        const fileUri = URI.file(cc.definition.path).toString();
+        let startPos = 0;
+        let endPos = 0;
+
+        targetDocument = getDocumentByFileUriSchemeOrPath(cc.definition.path, fileUri);
+
+        if (attributeName.startsWith('@')) {
+          attributeName = attributeName.slice(1);
+          const emitData = cc.info.componentInfo.emits?.filter(x => kebabCase(x.name) === kebabCase(attributeName))[0];
+          if (!emitData || !emitData.location) {
+            continue;
+          }
+
+          if (targetDocument) {
+            startPos = emitData.location.start;
+            endPos = emitData.location.end;
+          }
+        } else {
+          if (attributeName.startsWith(':')) {
+            attributeName = attributeName.slice(1);
+          }
+
+          const propData = cc.info.componentInfo.props?.filter(x => kebabCase(x.name) === kebabCase(attributeName))[0];
+          if (!propData || !propData.location) {
+            continue;
+          }
+
+          if (targetDocument) {
+            startPos = propData.location.start;
+            endPos = propData.location.end;
+          }
+        }
+
+        const loc: Location = {
+          uri: URI.file(cc.definition.path).toString(),
+          range: targetDocument
+            ? Range.create(targetDocument.positionAt(startPos), targetDocument.positionAt(endPos))
+            : Range.create(0, 0, 0, 0)
+        };
+        return [loc];
+      }
+    }
+    return [];
+  }
+
+  function getDocumentByFileUriSchemeOrPath(path: string, fileUri: string) {
+    let document = documentService.getDocument(fileUri);
+
+    if (document) {
+      return document;
+    }
+
+    // We need to read the file in case it was never opened and does not exist in documentService yet
+    document = TextDocument.create(fileUri, 'vue', 0, fs.readFileSync(path).toString());
+    return document;
   }
 
   const inEndTag = node.endTagStart && offset >= node.endTagStart; // <html></ht|ml>
@@ -77,6 +163,10 @@ export function findDefinition(
       return getTagDefinition(node.tag, tagRange, true);
     case TokenType.EndTag:
       return getTagDefinition(node.tag, tagRange, false);
+    case TokenType.AttributeName:
+      const attributeName = scanner.getTokenText();
+      const tagName = node.tag;
+      return getAttributeDefinition(tagName, attributeName);
   }
 
   return [];

--- a/server/src/modes/template/services/htmlDefinition.ts
+++ b/server/src/modes/template/services/htmlDefinition.ts
@@ -26,7 +26,7 @@ export function findDefinition(
   function getTagDefinition(tag: string, range: Range, open: boolean): Location[] {
     if (vueFileInfo && vueFileInfo.componentInfo.childComponents) {
       for (const cc of vueFileInfo.componentInfo.childComponents) {
-        if (![tag, tag.toLowerCase(), kebabCase(tag)].includes(kebabCase(cc.name))) {
+        if (![tag, tag.toLowerCase(), kebabCase(tag)].includes(cc.name.toLowerCase())) {
           continue;
         }
         if (!cc.definition) {
@@ -78,7 +78,9 @@ export function findDefinition(
 
         if (attributeName.startsWith('@')) {
           attributeName = attributeName.slice(1);
-          const emitData = cc.info.componentInfo.emits?.filter(x => kebabCase(x.name) === kebabCase(attributeName))[0];
+          const emitData = cc.info.componentInfo.emits?.filter(
+            x => x.name.toLowerCase() === attributeName.toLowerCase() || kebabCase(x.name) === kebabCase(attributeName)
+          )[0];
           if (!emitData || !emitData.location) {
             continue;
           }

--- a/server/src/modes/template/services/htmlHover.ts
+++ b/server/src/modes/template/services/htmlHover.ts
@@ -45,7 +45,6 @@ export function doHover(
 
   function getAttributeHover(tag: string, attribute: string, range: Range): Hover {
     tag = kebabCase(tag);
-    attribute = attribute;
     const isEventAttribute = attribute.startsWith('@');
 
     let hover: Hover | null = null;

--- a/server/src/modes/template/services/htmlHover.ts
+++ b/server/src/modes/template/services/htmlHover.ts
@@ -45,13 +45,23 @@ export function doHover(
 
   function getAttributeHover(tag: string, attribute: string, range: Range): Hover {
     tag = kebabCase(tag);
-    attribute = normalizeAttributeNameToKebabCase(attribute);
+    attribute = attribute;
+    const isEventAttribute = attribute.startsWith('@');
 
     let hover: Hover | null = null;
     const attributeCollector: AttributeCollector = (attr, type?, documentation?) => {
-      if (attribute !== normalizeAttributeNameToKebabCase(attr)) {
+      if (type === 'event' && !isEventAttribute) {
         return;
       }
+
+      if (type !== 'event' && isEventAttribute) {
+        return;
+      }
+
+      if (normalizeAttributeNameToKebabCase(attribute) !== normalizeAttributeNameToKebabCase(attr)) {
+        return;
+      }
+
       hover = { contents: toMarkupContent(documentation), range };
     };
 

--- a/server/src/modes/template/tagProviders/common.ts
+++ b/server/src/modes/template/tagProviders/common.ts
@@ -1,7 +1,7 @@
 import { MarkupContent } from 'vscode-languageserver-types';
 import { kebabCase } from 'lodash';
 
-interface TagCollector {
+export interface TagCollector {
   (tag: string, documentation: string | MarkupContent): void;
 }
 
@@ -52,7 +52,16 @@ export interface IValueSets {
 }
 
 export function getSameTagInSet<T>(tagSet: Record<string, T>, tag: string): T | undefined {
-  return tagSet[tag] ?? tagSet[tag.toLowerCase()] ?? tagSet[kebabCase(tag)];
+  for (const tagInTagSet in tagSet) {
+    const normalizedTagName = kebabCase(tag);
+    const normaliedtagInTagSetName = kebabCase(tagInTagSet);
+
+    if (normalizedTagName === normaliedtagInTagSetName) {
+      return tagSet[tagInTagSet];
+    }
+  }
+
+  return undefined;
 }
 
 export function collectTagsDefault(collector: TagCollector, tagSet: ITagSet): void {

--- a/server/src/modes/template/tagProviders/common.ts
+++ b/server/src/modes/template/tagProviders/common.ts
@@ -53,10 +53,7 @@ export interface IValueSets {
 
 export function getSameTagInSet<T>(tagSet: Record<string, T>, tag: string): T | undefined {
   for (const tagInTagSet in tagSet) {
-    const normalizedTagName = kebabCase(tag);
-    const normaliedtagInTagSetName = kebabCase(tagInTagSet);
-
-    if (normalizedTagName === normaliedtagInTagSetName) {
+    if (tagInTagSet.toLowerCase() === tag.toLowerCase() || kebabCase(tag) === kebabCase(tagInTagSet)) {
       return tagSet[tagInTagSet];
     }
   }

--- a/server/src/services/projectService.ts
+++ b/server/src/services/projectService.ts
@@ -98,7 +98,8 @@ export async function createProjectService(
     {
       infoService: vueInfoService,
       dependencyService,
-      refTokensService
+      refTokensService,
+      documentService
     },
     globalSnippetDir
   );
@@ -206,7 +207,7 @@ export async function createProjectService(
       const doc = documentService.getDocument(textDocument.uri)!;
       const mode = languageModes.getModeAtPosition(doc, position);
       if (mode && mode.findDefinition) {
-        return mode.findDefinition(doc, position);
+        return mode.findDefinition(doc, position, documentService);
       }
       return [];
     },

--- a/server/src/services/vueInfoService.ts
+++ b/server/src/services/vueInfoService.ts
@@ -67,6 +67,7 @@ export interface EmitInfo {
   hasValidator: boolean;
   documentation?: string;
   typeString?: string;
+  location: { start: number; end: number };
 }
 
 export interface PropInfo {
@@ -87,6 +88,7 @@ export interface PropInfo {
   isBoundToModel: boolean;
   documentation?: string;
   typeString?: string;
+  location: { start: number; end: number };
 }
 export interface DataInfo {
   name: string;

--- a/test/definitionHelper.ts
+++ b/test/definitionHelper.ts
@@ -11,6 +11,6 @@ export async function testDefinition(docUri: vscode.Uri, position: vscode.Positi
     position
   )) as vscode.Location[];
 
-  assert.ok(result[0].range.isEqual(expectedLocation.range));
-  assert.equal(result[0].uri.fsPath, expectedLocation.uri.fsPath);
+  assert.deepStrictEqual(result[0].range, expectedLocation.range);
+  assert.strictEqual(result[0].uri.fsPath, expectedLocation.uri.fsPath);
 }

--- a/test/interpolation/features/completion/basic.test.ts
+++ b/test/interpolation/features/completion/basic.test.ts
@@ -1,4 +1,4 @@
-import { CompletionItem, CompletionItemKind, MarkdownString } from 'vscode';
+import { CompletionItem, CompletionItemKind, ConfigurationTarget, MarkdownString, workspace } from 'vscode';
 import { position } from '../../../util';
 import { testCompletion, testNoSuchCompletion } from '../../../completionHelper';
 import { getDocUri } from '../../path';
@@ -61,7 +61,23 @@ describe('Should autocomplete interpolation for <template>', () => {
       ]);
     });
 
-    it(`completes child component tag`, async () => {
+    it(`completes child component tag (initial tag casing)`, async () => {
+      const c = workspace.getConfiguration();
+      await c.update('vetur.completion.tagCasing', 'initial', ConfigurationTarget.Global);
+
+      await testCompletion(parentTemplateDocUri, position(6, 5), [
+        {
+          label: 'Basic',
+          kind: CompletionItemKind.Property,
+          documentationStart: 'My basic tag\n```js\nexport default {'
+        }
+      ]);
+    });
+
+    it(`completes child component tag (kebab tag casing)`, async () => {
+      const c = workspace.getConfiguration();
+      await c.update('vetur.completion.tagCasing', 'kebab', ConfigurationTarget.Global);
+
       await testCompletion(parentTemplateDocUri, position(6, 5), [
         {
           label: 'basic',

--- a/test/interpolation/features/completion/property.test.ts
+++ b/test/interpolation/features/completion/property.test.ts
@@ -1,4 +1,4 @@
-import { CompletionItem, CompletionItemKind, MarkdownString } from 'vscode';
+import { CompletionItem, CompletionItemKind, ConfigurationTarget, MarkdownString, workspace } from 'vscode';
 import { getDocUri } from '../../path';
 import { testCompletion, testNoSuchCompletion } from '../../../completionHelper';
 import { position } from '../../../util';
@@ -101,6 +101,9 @@ describe('Should autocomplete interpolation for <template> in property class com
     });
 
     it(`completes child component's emits`, async () => {
+      const c = workspace.getConfiguration();
+      await c.update('vetur.completion.attributeCasing', 'kebab', ConfigurationTarget.Global);
+
       await testCompletion(parentTemplateDocUri, position(2, 27), [
         {
           label: 'baz',

--- a/test/interpolation/features/definition/basic.test.ts
+++ b/test/interpolation/features/definition/basic.test.ts
@@ -1,4 +1,4 @@
-import { position, sameLineLocation } from '../../../util';
+import { position, sameLineLocation, location } from '../../../util';
 import { getDocUri } from '../../path';
 import { testDefinition } from '../../../definitionHelper';
 
@@ -7,7 +7,7 @@ describe('Should find definition', () => {
 
   it('finds definition for child tag', async () => {
     const tagUri = getDocUri('definition/Child.vue');
-    await testDefinition(docUri, position(2, 5), sameLineLocation(tagUri, 0, 0, 0));
+    await testDefinition(docUri, position(2, 5), location(tagUri, 5, 15, 9, 1));
   });
 
   it('finds definition for test-bar tag', async () => {

--- a/test/interpolation/features/definition/class.test.ts
+++ b/test/interpolation/features/definition/class.test.ts
@@ -1,22 +1,61 @@
-import { position, sameLineLocation } from '../../../util';
+import { position, sameLineLocation, location } from '../../../util';
 import { getDocUri } from '../../path';
 import { testDefinition } from '../../../definitionHelper';
+import { ConfigurationTarget, workspace } from 'vscode';
 
-describe('Should find definition for vue-class-component components', () => {
+describe('Should find definition for vue-class-component components', async () => {
   const parentUri = getDocUri('definition/classComponent/Parent.vue');
+
+  const c = workspace.getConfiguration();
+  await c.update('vetur.completion.attributeCasing', 'initial', ConfigurationTarget.Global);
 
   it('finds definition for opening tag in <child></child>', async () => {
     const tagUri = getDocUri('definition/classComponent/Child.vue');
-    await testDefinition(parentUri, position(2, 5), sameLineLocation(tagUri, 0, 0, 0));
+    await testDefinition(parentUri, position(2, 5), location(tagUri, 8, 0, 16, 1));
   });
 
   it('finds definition for closing tag in <child></child>', async () => {
     const tagUri = getDocUri('definition/classComponent/Child.vue');
-    await testDefinition(parentUri, position(2, 13), sameLineLocation(tagUri, 0, 0, 0));
+    await testDefinition(parentUri, position(2, 13), location(tagUri, 8, 0, 16, 1));
   });
 
   it('finds definition for self-closing tag <child />', async () => {
     const tagUri = getDocUri('definition/classComponent/Child.vue');
-    await testDefinition(parentUri, position(3, 5), sameLineLocation(tagUri, 0, 0, 0));
+    await testDefinition(parentUri, position(3, 5), location(tagUri, 8, 0, 16, 1));
+  });
+
+  it('finds definition for self-closing tag <Child /> (PascalCase)', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(10, 5), location(tagUri, 8, 0, 16, 1));
+  });
+
+  it('finds definition for child property fooProperty (no binding)', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(4, 11), location(tagUri, 10, 3, 10, 42));
+  });
+
+  it('finds definition for child property :fooProperty (with binding)', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(5, 11), location(tagUri, 10, 3, 10, 42));
+  });
+
+  it('finds definition for child property foo-property (no binding)', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(6, 11), location(tagUri, 10, 3, 10, 42));
+  });
+
+  it('finds definition for child property :foo-property (with binding)', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(7, 11), location(tagUri, 10, 3, 10, 42));
+  });
+
+  it('finds definition for child event @fooEvent', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(8, 11), location(tagUri, 12, 3, 12, 19));
+  });
+
+  it('finds definition for child event @foo-event', async () => {
+    const tagUri = getDocUri('definition/classComponent/Child.vue');
+    await testDefinition(parentUri, position(9, 11), location(tagUri, 12, 3, 12, 19));
   });
 });

--- a/test/interpolation/fixture/completion/propertyDecorator/Parent.vue
+++ b/test/interpolation/fixture/completion/propertyDecorator/Parent.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <basic-property-class @></basic-property-class>
-    <basic-property-class v-if="" @click="" :foo=""></basic-property-class>
+    <basic-property-class v-if="" @click="" :foo="" ></basic-property-class>
     <BasicPropertyClass  />
     <
   </div>

--- a/test/interpolation/fixture/definition/classComponent/Child.vue
+++ b/test/interpolation/fixture/definition/classComponent/Child.vue
@@ -7,5 +7,12 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 
 @Component({})
-export default class BasicClass extends Vue {}
+export default class BasicClass extends Vue {
+  @Prop({ type: Boolean, default: false }) fooProperty
+
+  @Emit('fooEvent')
+  public fooEvent() {
+
+  }
+}
 </script>

--- a/test/interpolation/fixture/definition/classComponent/Parent.vue
+++ b/test/interpolation/fixture/definition/classComponent/Parent.vue
@@ -2,6 +2,14 @@
   <div>
     <child></child>
     <child />
+    <child fooProperty="propValue"/>
+    <child :fooProperty="'propValue'"/>
+    <child foo-property="propValue"/>
+    <child :foo-property="'propValue'"/>
+    <child @fooEvent=""/>
+    <child @foo-event=""/>
+    <Child />
+    
   </div>
 </template>
 


### PR DESCRIPTION
This PR enables HTML mode for properties and emits since most of the logic was already implemented but failed for some reason. 

- Hover/Go to definition (F12) for components, properties and emits, with a correctly highlighted location in the source file.
- vetur.completion.attributeCasing configuration key for choosing how attributes should be formatted for auto-completion