### PR TITLE
chore: replace deprecated vscode-test with @vscode/test-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -604,6 +604,7 @@
     "@types/node": "^15.12.4",
     "@types/shelljs": "^0.8.8",
     "@types/vscode": "^1.52.0",
+    "@vscode/test-electron": "^1.6.1",
     "esbuild": "^0.12.5",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
@@ -624,7 +625,6 @@
     "tslint": "^6.1.3",
     "typescript": "^4.3.2",
     "vscode-languageclient": "^7.0.0",
-    "vscode-languageserver-types": "^3.16.0",
-    "vscode-test": "^1.5.2"
+    "vscode-languageserver-types": "^3.16.0"
   }
 }

--- a/test/codeTestRunner.ts
+++ b/test/codeTestRunner.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import $ from 'shelljs';
 import minimist from 'minimist';
 
-import { downloadAndUnzipVSCode, runTests } from 'vscode-test';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
 console.log('### Vetur Integration Test ###');
 console.log('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@vscode/test-electron@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-1.6.1.tgz#2b282154097e250ee9b94b6a284eb5804e53a3d7"
+  integrity sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==
+  dependencies:
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    rimraf "^3.0.2"
+    unzipper "^0.10.11"
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -2155,16 +2165,6 @@ vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
-
-vscode-test@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.5.2.tgz#d9ec3cab1815afae1d7d81923e3c685d13d32303"
-  integrity sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==
-  dependencies:
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    rimraf "^3.0.2"
-    unzipper "^0.10.11"
 
 which@2.0.2, which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
![2021-07-18 15 55 53](https://user-images.githubusercontent.com/14012511/126060080-8d671595-14c2-43d2-8daa-e8ee579140c3.png)

vscode-test be marked as [deprecated](https://www.npmjs.com/package/vscode-test) on npmjs.org(yarnpkg.com), so just replace vscode-test with latest @vscode/test-electron for `vetur`'s CI. cc @octref  @yoyo930021 