### PR TITLE
Add editor sdk setup notes to Yarn PnP section

### DIFF
--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -176,3 +176,18 @@ Vetur supports this feature now, but has some limits.
 
 - Don't mix common project and pnp project in multi-root/monorepo
 - Prettier doesn't support Yarn PnP, so can't load plugin automatically.
+
+If you're using the editor SDKs with typescript and you want to use the typescript server wrapper created by yarn you'll need to set the `typescript.tsdk` to the directory of the editor sdk's tsserver:
+```javascript
+const path = require('path')
+
+// vetur.config.js
+/** @type {import('vls').VeturConfig} */
+module.exports = {
+  // **optional** default: `{}`
+  settings: {
+    "vetur.useWorkspaceDependencies": true,
+    "typescript.tsdk": path.resolve(__dirname, '.yarn/sdks/typescript/bin'),
+  },
+}
+```

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -177,7 +177,7 @@ Vetur supports this feature now, but has some limits.
 - Don't mix common project and pnp project in multi-root/monorepo
 - Prettier doesn't support Yarn PnP, so can't load plugin automatically.
 
-If you're using the editor SDKs with typescript and you want to use the typescript server wrapper created by yarn you'll need to set the `typescript.tsdk` to the directory of the editor sdk's tsserver:
+If you're using the editor SDKs ([Yarn Editor SDKs](https://yarnpkg.com/getting-started/editor-sdks)) with typescript and you want to use the typescript server wrapper created by yarn you'll need to set the `typescript.tsdk` to the directory of the editor sdk's tsserver:
 ```javascript
 const path = require('path')
 


### PR DESCRIPTION
In order to use Yarn's Typescript SDK we have to set the settings: `useWorkspaceDependencies` to true and then pass Yarn's Typescript SDK path to `typescript.tsdk`; I added an example with some notes to the Yarn PnP section of the setup guide to make it more obvious how to accomplish this.