### PR TITLE
fix(interpolation/v-for): allow optional index parameter for numeric iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Un release
+
+- 🙌 Add support to interpolation service for index parameter with number iteration. Thanks to contribution from [@thebanjomatic](https://github.com/thebanjomatic). #3222
+
 ### 0.35.0 | 2021-10-16 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.35.0/vspackage)
 
 ----

--- a/server/src/services/typescriptService/bridge.ts
+++ b/server/src/services/typescriptService/bridge.ts
@@ -30,7 +30,7 @@ export declare const ${componentHelperName}: {
 export declare const ${iterationHelperName}: {
   <T>(list: readonly T[], fn: (value: T, index: number) => any): any;
   <T>(obj: { [key: string]: T }, fn: (value: T, key: string, index: number) => any): any;
-  (num: number, fn: (value: number) => any): any;
+  (num: number, fn: (value: number, index: number) => any): any;
   <T>(obj: object, fn: (value: any, key: string, index: number) => any): any;
 };
 `;

--- a/test/interpolation/fixture/diagnostics/v-for.vue
+++ b/test/interpolation/fixture/diagnostics/v-for.vue
@@ -8,6 +8,9 @@
     <p v-for="i in 10" :key="i">
       {{ i }}
     </p>
+    <p v-for="(n, index) in 10" :key="n">
+      {{index}} | {{ n }}
+    </p>
   </div>
 </template>
 


### PR DESCRIPTION
The `v-for` directive when iterating over a number provides both the 1-based numeric value, and the 0-based index to the iteration function. Vetur currently shows this as an error when you are using the `experimental.templateInterpolationService` option and attempt to use the index.

Existing behavior:
![image](https://user-images.githubusercontent.com/17907922/139716888-8019e9f4-5316-45a2-ba53-9aa26135a72f.png)
```
No overload matches this call.
  The last overload gave the following error.
    Argument of type 'number' is not assignable to parameter of type 'object'.Vetur(2769)
```


This change adds the missing second parameter to the iteration helper for the `num: number` overload, and existing usages with a single parameter should continue to work.


<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->