### PR TITLE
Add support for checking `default` and `required` state of props set by variables (`Identifier`).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Un release
 
 - 🙌 Add support to interpolation service for index parameter with number iteration. Thanks to contribution from [@thebanjomatic](https://github.com/thebanjomatic). #3222
+- 🙌 Add support for checking `default` and `required` state of props set by variables (`Identifier`). Thanks to contribution from [@lordeleto]<https://github.com/lordeleto>.
 
 ### 0.35.0 | 2021-10-16 | [VSIX](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/octref/vsextensions/vetur/0.35.0/vspackage)
 

--- a/server/src/modes/script/componentInfo.ts
+++ b/server/src/modes/script/componentInfo.ts
@@ -457,7 +457,10 @@ function getProps(
       }
     }
 
-    if (!propertyValue || !tsModule.isObjectLiteralExpression(propertyValue)) {
+    if (
+      !propertyValue ||
+      (!tsModule.isObjectLiteralExpression(propertyValue) && !tsModule.isIdentifier(propertyValue))
+    ) {
       return { hasObjectValidator: false, required: true, typeString };
     }
 

--- a/test/interpolation/features/diagnostics/propsValidation.test.ts
+++ b/test/interpolation/features/diagnostics/propsValidation.test.ts
@@ -64,17 +64,17 @@ describe('Should find common diagnostics for all regions', () => {
   it('shows errors for passing wrong props to child component when using object validators', async () => {
     const expectedDiagnostics: vscode.Diagnostic[] = [
       {
-        message: '<object-validator-child> misses props: foo, bar',
+        message: '<object-validator-child> misses props: foo, bar, with-required, no-default-required',
         severity: vscode.DiagnosticSeverity.Error,
         range: sameLineRange(12, 4, 30)
       },
       {
-        message: '<object-validator-child> misses props: bar',
+        message: '<object-validator-child> misses props: bar, with-required, no-default-required',
         severity: vscode.DiagnosticSeverity.Error,
         range: sameLineRange(13, 4, 41)
       },
       {
-        message: '<object-validator-child> misses props: foo',
+        message: '<object-validator-child> misses props: foo, with-required, no-default-required',
         severity: vscode.DiagnosticSeverity.Error,
         range: sameLineRange(14, 4, 40)
       }

--- a/test/interpolation/fixture/diagnostics/propsValidation/object-validator-props-child.vue
+++ b/test/interpolation/fixture/diagnostics/propsValidation/object-validator-props-child.vue
@@ -1,4 +1,18 @@
 <script>
+const propertyAssignmentDefault = {
+  type: Boolean,
+  default: false,
+};
+
+const propertyAssignmentRequired = {
+  type: Boolean,
+  required: true,
+};
+
+const propertyAssignmentNoDefaultRequired = {
+  type: Boolean,
+};
+
 export default {
   model: {
     prop: 'foo'
@@ -19,7 +33,10 @@ export default {
     dar: {
       type: String,
       default: 'dar'
-    }
+    },
+    withDefault: propertyAssignmentDefault,
+    withRequired: propertyAssignmentRequired,
+    noDefaultRequired: propertyAssignmentNoDefaultRequired
   }
 }
 </script>

--- a/test/interpolation/fixture/diagnostics/propsValidation/pass-parent.vue
+++ b/test/interpolation/fixture/diagnostics/propsValidation/pass-parent.vue
@@ -2,7 +2,7 @@
   <div>
     <array-child :foo="foo" :bar="bar" :bAz="bar"></array-child>
     <array-child :foo="foo" :bar="bar" :b-az="bar"></array-child>
-    <object-validator-child v-model="foo" :bar="bar" />
+    <object-validator-child v-model="foo" :bar="bar" :no-default-required="true" :with-required="true" />
     <class-child v-bind="{}" />
     <class-child v-bind:[bar]="{}" />
     <class-child :[bar]="{}" />


### PR DESCRIPTION
This PR allows componentInfo to inspect the `default` and `required` properties of a prop that is set by a variable, i.e. a canned prop declaration.

Example:
CommonProps.ts
```
export const LabelProp = {
  type: String,
  required: true,
};

export const IsValidProp = {
  type: Boolean,
  default: false,
};
```
SampleComponent.vue
```
import Vue from 'vue';
import { LabelProp, IsValidProp } from './CommonProps.ts';

export default Vue.extend({
  name: 'SampleComponent',
  props: {
    label: LabelProp,
    valid: IsValidProp
  }
});
```