### PR TITLE
support `rootUri`

### DIFF
--- a/server/src/services/vls.ts
+++ b/server/src/services/vls.ts
@@ -111,11 +111,17 @@ export class VLS {
   }
 
   async init(params: InitializeParams) {
+    let rootFsPath = '';
+    if (params.rootPath) {
+      rootFsPath = normalizeFileNameToFsPath(params.rootPath);
+    } else if (params.rootUri) {
+      rootFsPath = getFileFsPath(params.rootUri);
+    }
     const workspaceFolders =
       Array.isArray(params.workspaceFolders) && params.capabilities.workspace?.workspaceFolders
         ? params.workspaceFolders.map(el => ({ name: el.name, fsPath: getFileFsPath(el.uri) }))
-        : params.rootPath
-        ? [{ name: '', fsPath: normalizeFileNameToFsPath(params.rootPath) }]
+        : rootFsPath
+        ? [{ name: '', fsPath: rootFsPath }]
         : [];
 
     if (workspaceFolders.length === 0) {


### PR DESCRIPTION
so far, for anything to work, either `rootPath` or `workspaceFolders` need to be set. `rootUri` is a bit "less deprecated" than `rootPath` (https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize), so for increased compatibility with LSP clients, I think we should also support that, especially given it is so little effort. Does this make sense to you?
(Example client where this situation applies: https://github.com/AndCake/micro-plugin-lsp/issues/1)

I can't guarantee the tests will all succeed, as for some reason, the test setup fails on my system (even on master). But I guess CI will fire once I submit this PR