### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/server/src/embeddedSupport/vueDocumentRegionParser.ts
+++ b/server/src/embeddedSupport/vueDocumentRegionParser.ts
@@ -159,7 +159,7 @@ function scanTemplateRegion(scanner: Scanner, text: string): EmbeddedRegion | nu
       } else if (token === TokenType.Unknown) {
         if (scanner.getTokenText().charAt(0) === '<') {
           const offset = scanner.getTokenOffset();
-          const unknownText = text.substr(offset, 11);
+          const unknownText = text.slice(offset, offset + 11);
           if (unknownText === '</template>') {
             unClosedTemplate--;
             // test leading </template>
@@ -231,7 +231,7 @@ function scanCustomRegion(tagName: string, scanner: Scanner, text: string): Embe
       } else if (token === TokenType.Unknown) {
         if (scanner.getTokenText().charAt(0) === '<') {
           const offset = scanner.getTokenOffset();
-          const unknownText = text.substr(offset, `</${tagName}>`.length);
+          const unknownText = text.slice(offset, offset + `</${tagName}>`.length);
           if (unknownText === `</${tagName}>`) {
             unClosedTag--;
             // test leading </${tagName}>

--- a/server/src/modes/script/previewer.ts
+++ b/server/src/modes/script/previewer.ts
@@ -51,7 +51,7 @@ function getTagBodyText(tag: ts.JSDocTagInfo): string | undefined {
       // check for caption tags, fix for #79704
       const captionTagMatches = plain(tag.text).match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
       if (captionTagMatches && captionTagMatches.index === 0) {
-        return captionTagMatches[1] + '\n\n' + makeCodeblock(plain(tag.text).substr(captionTagMatches[0].length));
+        return captionTagMatches[1] + '\n\n' + makeCodeblock(plain(tag.text).slice(captionTagMatches[0].length));
       } else {
         return makeCodeblock(plain(tag.text));
       }

--- a/server/src/modes/template/parser/htmlScanner.ts
+++ b/server/src/modes/template/parser/htmlScanner.ts
@@ -102,7 +102,7 @@ class MultiLineStream {
   }
 
   public advanceIfRegExp(regex: RegExp): string {
-    const str = this.source.substr(this.position);
+    const str = this.source.slice(this.position);
     const match = str.match(regex);
     if (match) {
       this.position = this.position + match.index! + match[0].length;
@@ -112,7 +112,7 @@ class MultiLineStream {
   }
 
   public advanceUntilRegExp(regex: RegExp): string {
-    const str = this.source.substr(this.position);
+    const str = this.source.slice(this.position);
     const match = str.match(regex);
     if (match) {
       this.position = this.position + match.index!;

--- a/server/src/modes/template/test/highlighting.test.ts
+++ b/server/src/modes/template/test/highlighting.test.ts
@@ -12,7 +12,7 @@ import { findDocumentHighlights } from '../services/htmlHighlighting';
 suite('HTML Highlighting', () => {
   function assertHighlights(value: string, expectedMatches: number[], elementName: string | null): void {
     const offset = value.indexOf('|');
-    value = value.substr(0, offset) + value.substr(offset + 1);
+    value = value.substring(0, offset) + value.slice(offset + 1);
 
     const document = TextDocument.create('test://test/test.html', 'html', 0, value);
 

--- a/server/src/modes/template/test/highlighting.test.ts
+++ b/server/src/modes/template/test/highlighting.test.ts
@@ -12,7 +12,7 @@ import { findDocumentHighlights } from '../services/htmlHighlighting';
 suite('HTML Highlighting', () => {
   function assertHighlights(value: string, expectedMatches: number[], elementName: string | null): void {
     const offset = value.indexOf('|');
-    value = value.substring(0, offset) + value.slice(offset + 1);
+    value = value.slice(0, offset) + value.slice(offset + 1);
 
     const document = TextDocument.create('test://test/test.html', 'html', 0, value);
 

--- a/server/src/modes/template/test/scanner.test.ts
+++ b/server/src/modes/template/test/scanner.test.ts
@@ -23,7 +23,7 @@ suite('HTML Scanner', () => {
       while (tokenType !== TokenType.EOS) {
         const actualToken: Token = { offset: scanner.getTokenOffset(), type: tokenType };
         if (tokenType === TokenType.StartTag || tokenType === TokenType.EndTag) {
-          actualToken.content = t.input.substr(scanner.getTokenOffset(), scanner.getTokenLength());
+          actualToken.content = t.input.slice(scanner.getTokenOffset(), scanner.getTokenOffset() + scanner.getTokenLength());
         }
         actual.push(actualToken);
         tokenType = scanner.scan();

--- a/server/src/modes/test-util/completion-test-util.ts
+++ b/server/src/modes/test-util/completion-test-util.ts
@@ -18,7 +18,7 @@ export interface CompletionTestSetup {
 export function testDSL(setup: CompletionTestSetup): (text: TemplateStringsArray) => CompletionAsserter {
   return function test([value]: TemplateStringsArray) {
     const offset = value.indexOf('|');
-    value = value.substr(0, offset) + value.substr(offset + 1);
+    value = value.substring(0, offset) + value.slice(offset + 1);
 
     const document = TextDocument.create(setup.docUri, setup.langId, 0, value);
     const position = document.positionAt(offset);

--- a/server/src/modes/test-util/hover-test-util.ts
+++ b/server/src/modes/test-util/hover-test-util.ts
@@ -34,7 +34,7 @@ export class HoverAsserter {
 export function hoverDSL(setup: HoverTestSetup) {
   return function test([value]: TemplateStringsArray) {
     const offset = value.indexOf('|');
-    value = value.substr(0, offset) + value.substr(offset + 1);
+    value = value.substring(0, offset) + value.slice(offset + 1);
     const document = TextDocument.create(setup.docUri, setup.langId, 0, value);
 
     const position = document.positionAt(offset);

--- a/server/src/modes/test-util/hover-test-util.ts
+++ b/server/src/modes/test-util/hover-test-util.ts
@@ -34,7 +34,7 @@ export class HoverAsserter {
 export function hoverDSL(setup: HoverTestSetup) {
   return function test([value]: TemplateStringsArray) {
     const offset = value.indexOf('|');
-    value = value.substring(0, offset) + value.slice(offset + 1);
+    value = value.slice(0, offset) + value.slice(offset + 1);
     const document = TextDocument.create(setup.docUri, setup.langId, 0, value);
 
     const position = document.positionAt(offset);

--- a/server/src/modes/test/region.test.ts
+++ b/server/src/modes/test/region.test.ts
@@ -86,7 +86,7 @@ function testcase(description: string) {
       let content = generateContent();
       const offset = content.indexOf('|');
       if (offset >= 0) {
-        content = content.substr(0, offset) + content.substr(offset + 1);
+        content = content.slice(0, offset) + content.slice(offset + 1);
       }
       const doc = TextDocument.create('test://test/test.vue', 'vue', 0, content);
 

--- a/server/src/utils/strings.ts
+++ b/server/src/utils/strings.ts
@@ -10,7 +10,7 @@ export function getWordAtText(text: string, offset: number, wordDefinition: RegE
     lineStart--;
   }
   const offsetInLine = offset - lineStart;
-  const lineText = text.substr(lineStart);
+  const lineText = text.slice(lineStart);
 
   // make a copy of the regex as to not keep the state
   const flags = wordDefinition.ignoreCase ? 'gi' : 'g';


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.