### PR TITLE
Fixes vuejs/vetur#3485

### DIFF
--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -8,6 +8,7 @@
 
 ## VS Code Config
 
+- Navigate to your VS Code settings. On Windows/Linux - File > Preferences > Settings. On macOS - Code > Preferences > Settings.
 - Add `vue` to your `eslint.validate` setting, for example:
 
   ```json


### PR DESCRIPTION
Simply added some more information on how to navigate to VS Code's ```settings.json``` in the docs.